### PR TITLE
Bump package version to 1.2.1

### DIFF
--- a/zp-relayer/package.json
+++ b/zp-relayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zp-relayer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {

--- a/zp-relayer/package.json
+++ b/zp-relayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zp-relayer",
-  "version": "1.1.28",
+  "version": "1.2.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {


### PR DESCRIPTION
The previous version 1.2.0 formally was on https://github.com/zkBob/zeropool-relayer/commit/7c587c31d7f6e0151403bcaebd43586735bb3f84