### PR TITLE
Add endpoints for parameters hash

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -10,7 +10,8 @@
 | RELAYER_GAS_LIMIT | Gas limit for pool transactions | integer |
 | RELAYER_FEE | Minimal accepted relayer fee (in tokens | integer |
 | MAX_NATIVE_AMOUNT_FAUCET | Maximal amount of faucet value (in ETH) | integer |
-| TREE_UPDATE_PARAMS_PATH | Local path to tree update parameters | string |
+| TREE_UPDATE_PARAMS_PATH | Local path to tree update circuit parameters | string |
+| TRANSFER_PARAMS_PATH | Local path to transfer circuit parameters | string |
 | TX_VK_PATH | Local path to transaction curcuit verification key | string |
 | GAS_PRICE_FALLBACK | Default fallback gas price | integer |
 | GAS_PRICE_ESTIMATION_TYPE | Gas price estimation type | `web3` / `gas-price-oracle` / `eip1559-gas-estimation` / `polygon-gasstation-v2` |

--- a/zp-relayer/config.ts
+++ b/zp-relayer/config.ts
@@ -17,6 +17,7 @@ const config = {
   relayerFee: toBN(process.env.RELAYER_FEE as string),
   maxFaucet: toBN(process.env.MAX_NATIVE_AMOUNT_FAUCET as string),
   treeUpdateParamsPath: process.env.TREE_UPDATE_PARAMS_PATH || './params/tree_params.bin',
+  transferParamsPath: process.env.TRANSFER_PARAMS_PATH || './params/transfer_params.bin',
   txVKPath: process.env.TX_VK_PATH || './params/transfer_verification_key.json',
   gasPriceFallback: process.env.GAS_PRICE_FALLBACK as string,
   gasPriceEstimationType: (process.env.GAS_PRICE_ESTIMATION_TYPE as EstimationType) || 'web3',

--- a/zp-relayer/endpoints.ts
+++ b/zp-relayer/endpoints.ts
@@ -163,6 +163,13 @@ async function getLimits(req: Request, res: Response) {
   res.json(limitsFetch)
 }
 
+function getParamsHash(type: 'tree' | 'transfer') {
+  const hash = type === 'tree' ? pool.treeParamsHash : pool.transferParamsHash
+  return (req: Request, res: Response) => {
+    res.json({ hash })
+  }
+}
+
 function root(req: Request, res: Response) {
   return res.sendStatus(200)
 }
@@ -177,5 +184,6 @@ export default {
   relayerInfo,
   getFee,
   getLimits,
+  getParamsHash,
   root,
 }

--- a/zp-relayer/router.ts
+++ b/zp-relayer/router.ts
@@ -37,5 +37,7 @@ router.get('/job/:id', wrapErr(endpoints.getJob))
 router.get('/info', wrapErr(endpoints.relayerInfo))
 router.get('/fee', wrapErr(endpoints.getFee))
 router.get('/limits', wrapErr(endpoints.getLimits))
+router.get('/params/hash/tree', wrapErr(endpoints.getParamsHash('tree')))
+router.get('/params/hash/tx', wrapErr(endpoints.getParamsHash('transfer')))
 
 export default router


### PR DESCRIPTION
Implemented two endpoints: `/params/hash/tx` and `/params/hash/tree`.
`/params/hash/tx` returns sha256 hash of parameters used for transfer circuit.
`/params/hash/tree` returns sha256 hash of parameters used for tree update circuit.

Both endpoints respond with a json in the form of:
```
{
    "hash": "4a0a5571666b41216772ca8f4ac5c6fe37014169a21b0f33d893d2e1a0506e2f"
}
```