### PR TITLE
Move tx validation step into worker

### DIFF
--- a/zp-relayer/pool.ts
+++ b/zp-relayer/pool.ts
@@ -11,7 +11,6 @@ import { logger } from './services/appLogger'
 import { poolTxQueue } from './queue/poolTxQueue'
 import { getBlockNumber, getEvents, getTransaction } from './utils/web3'
 import { Helpers, Params, Proof, SnarkProof, VK } from 'libzkbob-rs-node'
-import { validateTx } from './validateTx'
 import { PoolState } from './state'
 
 import { TxType } from 'zp-memo-parser'
@@ -103,10 +102,6 @@ class Pool {
   }
 
   async transact(txs: PoolTx[]) {
-    for (const tx of txs) {
-      await validateTx(tx)
-    }
-
     const queueTxs = txs.map(({ proof, txType, memo, depositSignature }) => {
       return {
         amount: '0',

--- a/zp-relayer/workers/poolTxWorker.ts
+++ b/zp-relayer/workers/poolTxWorker.ts
@@ -12,7 +12,7 @@ import { sentTxQueue } from '@/queue/sentTxQueue'
 import { processTx } from '@/txProcessor'
 import config from '@/config'
 import { redis } from '@/services/redisClient'
-import { checkAssertion, checkNullifier, checkTransferIndex, parseDelta } from '@/validateTx'
+import { parseDelta, validateTx } from '@/validateTx'
 import type { EstimationType, GasPrice } from '@/services/gas-price'
 import type { Mutex } from 'async-mutex'
 import { getChainId } from '@/utils/web3'
@@ -40,9 +40,7 @@ export async function createPoolTxWorker<T extends EstimationType>(gasPrice: Gas
       const outCommit = txProof.inputs[2]
       const delta = parseDelta(txProof.inputs[3])
 
-      await checkAssertion(() => checkNullifier(nullifier, pool.state.nullifiers))
-      await checkAssertion(() => checkNullifier(nullifier, pool.optimisticState.nullifiers))
-      await checkAssertion(() => checkTransferIndex(toBN(pool.optimisticState.getNextIndex()), delta.transferIndex))
+      await validateTx(tx, delta, nullifier)
 
       const { data, commitIndex } = await processTx(job.id as string, tx, pool)
 


### PR DESCRIPTION
Closes #58 
Changed `logger.error` to `logger.warn` in `checkAssertion` function

Closes #68 
Previously tx validation was split in two steps: before submitting a job and during job processing by a worker. I decided to make all validation checks only in pool worker and moved `validateTx` function to make it more consistent. Now, relayer will not return status code 500 on `Incorrect transfer proof` and other validation errors that we saw. Such errors are stored directly in job and can be retrieved using `/job/:id`.

Note: validation assertions didn't change. Relayer performs same checks as before