### PR TITLE
Update ZkBobPool ABI

### DIFF
--- a/zp-relayer/abi/pool-abi.json
+++ b/zp-relayer/abi/pool-abi.json
@@ -70,6 +70,25 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "tier",
+        "type": "uint8"
+      }
+    ],
+    "name": "UpdateTier",
+    "type": "event"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -170,6 +189,11 @@
             "internalType": "uint256",
             "name": "depositCap",
             "type": "uint256"
+          },
+          {
+            "internalType": "uint8",
+            "name": "tier",
+            "type": "uint8"
           }
         ],
         "internalType": "struct ZkBobAccounting.Limits",
@@ -318,6 +342,11 @@
   {
     "inputs": [
       {
+        "internalType": "uint8",
+        "name": "_tier",
+        "type": "uint8"
+      },
+      {
         "internalType": "uint256",
         "name": "_tvlCap",
         "type": "uint256"
@@ -357,6 +386,24 @@
       }
     ],
     "name": "setOperatorManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "_tier",
+        "type": "uint8"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_users",
+        "type": "address[]"
+      }
+    ],
+    "name": "setUsersTier",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -421,7 +468,18 @@
     "type": "function"
   },
   {
-    "inputs": [],
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      }
+    ],
     "name": "withdrawFee",
     "outputs": [],
     "stateMutability": "nonpayable",

--- a/zp-relayer/pool.ts
+++ b/zp-relayer/pool.ts
@@ -36,6 +36,7 @@ export interface Limits {
   dailyUserDepositCap: BN
   dailyUserDepositCapUsage: BN
   depositCap: BN
+  tier: BN
 }
 
 export interface LimitsFetch {
@@ -60,6 +61,7 @@ export interface LimitsFetch {
       available: string
     }
   }
+  tier: string
 }
 
 class Pool {
@@ -234,6 +236,7 @@ class Pool {
       dailyUserDepositCap: toBN(limits.dailyUserDepositCap),
       dailyUserDepositCapUsage: toBN(limits.dailyUserDepositCapUsage),
       depositCap: toBN(limits.depositCap),
+      tier: toBN(limits.tier),
     }
   }
 
@@ -260,6 +263,7 @@ class Pool {
           available: limits.dailyWithdrawalCap.sub(limits.dailyWithdrawalCapUsage).toString(10),
         },
       },
+      tier: limits.tier.toString(10),
     }
     return limitsFetch
   }


### PR DESCRIPTION
Update ABI for pool contract. This changes will not break current functionality. Limits checks are performed using `getLimitsFor` contract function which returns corresponding user's limits:
https://github.com/zkBob/zeropool-relayer/blob/999efcc15757204c37758407130eaa9e4b45d1a9/zp-relayer/validateTx.ts#L229-L230

Added new field `tier` in response for `/limits` endpoint. Now, it has the following structure:
```
{
  deposit: {
    singleOperation: string
    daylyForAddress: {
      total: string
      available: string
    }
    daylyForAll: {
      total: string
      available: string
    }
    poolLimit: {
      total: string
      available: string
    }
  }
  withdraw: {
    daylyForAll: {
      total: string
      available: string
    }
  }
  tier: string
}
```