### PR TITLE
Fix tx resend

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -18,6 +18,7 @@
 | GAS_PRICE_SPEED_TYPE | This parameter specifies the desirable transaction speed | `instant` / `fast` / `standard` / `low` |
 | GAS_PRICE_FACTOR | A value that will multiply the gas price of the oracle to convert it to gwei. If the oracle API returns gas prices in gwei then this can be set to `1`. Also, it could be used to intentionally pay more gas than suggested by the oracle to guarantee the transaction verification. E.g. `1.25` or `1.5`. | integer |
 | GAS_PRICE_UPDATE_INTERVAL | Interval in milliseconds used to get the updated gas price value using specified estimation type | integer |
+| MAX_FEE_PER_GAS_LIMIT | Max limit on `maxFeePerGas` parameter for each transaction in wei | integer |
 | START_BLOCK | The block number used to start searching for events when the relayer instance is run for the first time | integer
 | EVENTS_PROCESSING_BATCH_SIZE | Batch size for one `eth_getLogs` request when reprocessing old logs. Defaults to `10000` | integer
 | RELAYER_LOG_LEVEL | Log level | Winston log level |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -24,4 +24,6 @@
 | RELAYER_LOG_LEVEL | Log level | Winston log level |
 | RELAYER_REDIS_URL | Url to redis instance | URL |
 | RPC_URL | Url to RPC node | URL |
-| SENT_TX_DELAY | Delay in milliseconds for sentTxWorker to verify submitted transactions | integer
+| SENT_TX_DELAY | Delay in milliseconds for sentTxWorker to verify submitted transactions | integer |
+| PERMIT_DEADLINE_THRESHOLD_INITIAL | Minimum time threshold in seconds for permit signature deadline to be valid (before initial transaction submition) | integer |
+| PERMIT_DEADLINE_THRESHOLD_RESEND | Minimum time threshold in seconds for permit signature deadline to be valid (for re-send attempts) | integer |

--- a/yarn.lock
+++ b/yarn.lock
@@ -6765,6 +6765,3 @@ yocto-queue@^0.1.0:
   dependencies:
     borsh "^0.5.0"
     buffer "^6.0.3"
-    stream-http "^3.2.0"
-    web3 "1.7.4"
-    webpack "^5.46.0"

--- a/zp-memo-parser/memo.ts
+++ b/zp-memo-parser/memo.ts
@@ -1,7 +1,5 @@
-import BN from 'bn.js'
 import { Buffer } from 'buffer'
 import { deserialize, BinaryReader } from 'borsh'
-import { toBN } from 'web3-utils'
 
 type Option<T> = T | null
 
@@ -13,16 +11,16 @@ export enum TxType {
 }
 
 interface DefaultTxData {
-  fee: BN
+  fee: string
 }
 
 export interface WithdrawTxData extends DefaultTxData {
-  nativeAmount: BN
+  nativeAmount: string
   reciever: Uint8Array
 }
 
 export interface PermittableDepositTxData extends DefaultTxData {
-  deadline: BN
+  deadline: string
   holder: Uint8Array
 }
 
@@ -97,7 +95,7 @@ function getNoteHashes(rawHashes: Buffer, num: number, maxNotes: number): Uint8A
 export function getTxData(data: Buffer, txType: Option<TxType>): TxData {
   function readU64(offset: number) {
     let uint = data.readBigUInt64BE(offset)
-    return toBN(uint.toString())
+    return uint.toString(10)
   }
   let offset = 0
   const fee = readU64(offset)

--- a/zp-memo-parser/package.json
+++ b/zp-memo-parser/package.json
@@ -12,9 +12,6 @@
   },
   "dependencies": {
     "borsh": "^0.5.0",
-    "buffer": "^6.0.3",
-    "stream-http": "^3.2.0",
-    "webpack": "^5.46.0",
-    "web3": "1.7.4"
+    "buffer": "^6.0.3"
   }
 }

--- a/zp-relayer/config.ts
+++ b/zp-relayer/config.ts
@@ -31,6 +31,8 @@ const config = {
   redisUrl: process.env.RELAYER_REDIS_URL,
   rpcUrl: process.env.RPC_URL as string,
   sentTxDelay: parseInt(process.env.SENT_TX_DELAY || '30000'),
+  permitDeadlineThresholdInitial: parseInt(process.env.PERMIT_DEADLINE_THRESHOLD_INITIAL || '300'),
+  permitDeadlineThresholdResend: parseInt(process.env.PERMIT_DEADLINE_THRESHOLD_RESEND || '10'),
 }
 
 export default config

--- a/zp-relayer/config.ts
+++ b/zp-relayer/config.ts
@@ -24,6 +24,7 @@ const config = {
   gasPriceSpeedType: (process.env.GAS_PRICE_SPEED_TYPE as GasPriceKey) || 'fast',
   gasPriceFactor: parseInt(process.env.GAS_PRICE_FACTOR || '1'),
   gasPriceUpdateInterval: parseInt(process.env.GAS_PRICE_UPDATE_INTERVAL || '5000'),
+  maxFeeLimit: process.env.MAX_FEE_PER_GAS_LIMIT ? toBN(process.env.MAX_FEE_PER_GAS_LIMIT) : null,
   startBlock: parseInt(process.env.START_BLOCK || '0'),
   eventsProcessingBatchSize: parseInt(process.env.EVENTS_PROCESSING_BATCH_SIZE || '10000'),
   logLevel: process.env.RELAYER_LOG_LEVEL || 'debug',

--- a/zp-relayer/init.ts
+++ b/zp-relayer/init.ts
@@ -15,6 +15,7 @@ export async function init() {
   const gasPriceService = new GasPrice(web3, config.gasPriceUpdateInterval, config.gasPriceEstimationType, {
     speedType: config.gasPriceSpeedType,
     factor: config.gasPriceFactor,
+    maxFeeLimit: config.maxFeeLimit,
   })
   await gasPriceService.start()
   const workerMutex = new Mutex()

--- a/zp-relayer/package.json
+++ b/zp-relayer/package.json
@@ -10,7 +10,7 @@
     "dev:worker": "ts-node poolTxWorker.ts",
     "start:dev": "ts-node index.ts",
     "start:prod": "node index.js",
-    "test": "ts-mocha --timeout 1000000 test/**/*.test.ts"
+    "test": "ts-mocha --paths --timeout 1000000 test/**/*.test.ts"
   },
   "dependencies": {
     "@metamask/eth-sig-util": "^4.0.1",

--- a/zp-relayer/pool.ts
+++ b/zp-relayer/pool.ts
@@ -8,6 +8,7 @@ import { Contract } from 'web3-eth-contract'
 import config from './config'
 import { web3 } from './services/web3'
 import { logger } from './services/appLogger'
+import { redis } from './services/redisClient'
 import { poolTxQueue } from './queue/poolTxQueue'
 import { getBlockNumber, getEvents, getTransaction } from './utils/web3'
 import { Helpers, Params, Proof, SnarkProof, VK } from 'libzkbob-rs-node'
@@ -84,8 +85,8 @@ class Pool {
     const txVK = require(config.txVKPath)
     this.txVK = txVK
 
-    this.state = new PoolState('pool')
-    this.optimisticState = new PoolState('optimistic')
+    this.state = new PoolState('pool', redis)
+    this.optimisticState = new PoolState('optimistic', redis)
   }
 
   private static getHash(path: string) {

--- a/zp-relayer/queue/sentTxQueue.ts
+++ b/zp-relayer/queue/sentTxQueue.ts
@@ -1,11 +1,10 @@
 import { Queue, QueueScheduler } from 'bullmq'
 import { redis } from '@/services/redisClient'
 import { SENT_TX_QUEUE_NAME } from '@/utils/constants'
-import { TxPayload } from './poolTxQueue'
 import type { TransactionConfig } from 'web3-core'
+import { GasPriceValue } from '@/services/gas-price'
 
 export interface SentTxPayload {
-  payload: TxPayload
   root: string
   outCommit: string
   commitIndex: number
@@ -13,13 +12,22 @@ export interface SentTxPayload {
   txData: string
   txConfig: TransactionConfig
   nullifier: string
+  gasPriceOptions: GasPriceValue
 }
+
+export enum SentTxState {
+  MINED = 'MINED',
+  REVERT = 'REVERT',
+  RESEND = 'RESEND',
+}
+
+export type SentTxResult = [SentTxState, string]
 
 // Required for delayed jobs processing
 const sentTxQueueScheduler = new QueueScheduler(SENT_TX_QUEUE_NAME, {
   connection: redis,
 })
 
-export const sentTxQueue = new Queue<SentTxPayload, string>(SENT_TX_QUEUE_NAME, {
+export const sentTxQueue = new Queue<SentTxPayload, SentTxResult>(SENT_TX_QUEUE_NAME, {
   connection: redis,
 })

--- a/zp-relayer/queue/sentTxQueue.ts
+++ b/zp-relayer/queue/sentTxQueue.ts
@@ -19,6 +19,7 @@ export enum SentTxState {
   MINED = 'MINED',
   REVERT = 'REVERT',
   RESEND = 'RESEND',
+  FAILED = 'FAILED',
 }
 
 export type SentTxResult = [SentTxState, string]

--- a/zp-relayer/queue/sentTxQueue.ts
+++ b/zp-relayer/queue/sentTxQueue.ts
@@ -3,16 +3,19 @@ import { redis } from '@/services/redisClient'
 import { SENT_TX_QUEUE_NAME } from '@/utils/constants'
 import type { TransactionConfig } from 'web3-core'
 import { GasPriceValue } from '@/services/gas-price'
+import { TxData, TxType } from 'zp-memo-parser'
 
 export interface SentTxPayload {
+  txType: TxType
   root: string
   outCommit: string
   commitIndex: number
   txHash: string
-  txData: string
+  prefixedMemo: string
   txConfig: TransactionConfig
   nullifier: string
   gasPriceOptions: GasPriceValue
+  txData: TxData
 }
 
 export enum SentTxState {

--- a/zp-relayer/services/gas-price/GasPrice.ts
+++ b/zp-relayer/services/gas-price/GasPrice.ts
@@ -58,7 +58,7 @@ export function EIP1559GasPriceWithinLimit(fees: EIP1559GasPrice, maxFeeLimit: B
     return fees
   } else {
     const maxFeePerGas = maxFeeLimit.toString(10)
-    const maxPriorityFeePerGas = BN.max(toBN(fees.maxPriorityFeePerGas).sub(diff), toBN(0)).toString(10)
+    const maxPriorityFeePerGas = BN.min(toBN(fees.maxPriorityFeePerGas), maxFeeLimit).toString(10)
     return {
       maxFeePerGas,
       maxPriorityFeePerGas,

--- a/zp-relayer/services/gas-price/types.ts
+++ b/zp-relayer/services/gas-price/types.ts
@@ -1,8 +1,8 @@
 // GasPrice fields
-interface LegacyGasPrice {
+export interface LegacyGasPrice {
   gasPrice: string
 }
-interface EIP1559GasPrice {
+export interface EIP1559GasPrice {
   maxFeePerGas: string
   maxPriorityFeePerGas: string
 }

--- a/zp-relayer/services/gas-price/types.ts
+++ b/zp-relayer/services/gas-price/types.ts
@@ -1,3 +1,5 @@
+import type BN from 'bn.js'
+
 // GasPrice fields
 export interface LegacyGasPrice {
   gasPrice: string
@@ -38,7 +40,7 @@ export type EstimationPolygonGSV2 = 'polygon-gasstation-v2'
 export type EstimationType = EstimationEIP1559 | EstimationOracle | EstimationWeb3 | EstimationPolygonGSV2
 
 export type EstimationOracleOptions = { speedType: GasPriceKey; factor: number }
-export type EstimationPolygonGSV2Options = { speedType: GasPriceKey }
+export type EstimationPolygonGSV2Options = { speedType: GasPriceKey; maxFeeLimit: BN | null }
 export type EstimationOptions<ET extends EstimationType> = ET extends EstimationOracle
   ? EstimationOracleOptions
   : ET extends EstimationPolygonGSV2

--- a/zp-relayer/state/PoolState.ts
+++ b/zp-relayer/state/PoolState.ts
@@ -1,3 +1,4 @@
+import type { Redis } from 'ioredis'
 import { logger } from '@/services/appLogger'
 import { OUTPLUSONE } from '@/utils/constants'
 import { MerkleTree, TxStorage, MerkleProof, Constants, Helpers } from 'libzkbob-rs-node'
@@ -10,11 +11,11 @@ export class PoolState {
   public nullifiers: NullifierSet
   public roots: RootSet
 
-  constructor(private name: string) {
+  constructor(private name: string, redis: Redis) {
     this.tree = new MerkleTree(`./${name}Tree.db`)
     this.txs = new TxStorage(`./${name}Txs.db`)
-    this.nullifiers = new NullifierSet(`${name}-nullifiers`)
-    this.roots = new RootSet(`${name}-roots`)
+    this.nullifiers = new NullifierSet(`${name}-nullifiers`, redis)
+    this.roots = new RootSet(`${name}-roots`, redis)
   }
 
   getVirtualTreeProofInputs(outCommit: string, transferNum?: number) {

--- a/zp-relayer/state/nullifierSet.ts
+++ b/zp-relayer/state/nullifierSet.ts
@@ -1,23 +1,22 @@
-import { redis } from '../services/redisClient'
-
+import type { Redis } from 'ioredis'
 export class NullifierSet {
-  constructor(public name: string) {}
+  constructor(public name: string, private redis: Redis) {}
 
   async add(nullifiers: string[]) {
     if (nullifiers.length === 0) return
-    await redis.sadd(this.name, nullifiers)
+    await this.redis.sadd(this.name, nullifiers)
   }
 
   async remove(nullifiers: string[]) {
     if (nullifiers.length === 0) return
-    await redis.srem(this.name, nullifiers)
+    await this.redis.srem(this.name, nullifiers)
   }
 
   async isInSet(nullifier: string) {
-    return await redis.sismember(this.name, nullifier)
+    return await this.redis.sismember(this.name, nullifier)
   }
 
   async clear() {
-    await redis.del(this.name)
+    await this.redis.del(this.name)
   }
 }

--- a/zp-relayer/state/rootSet.ts
+++ b/zp-relayer/state/rootSet.ts
@@ -1,23 +1,23 @@
-import { redis } from '@/services/redisClient'
+import type { Redis } from 'ioredis'
 
 export class RootSet {
-  constructor(public name: string) {}
+  constructor(public name: string, private redis: Redis) {}
 
   async add(roots: Record<number, string>) {
     if (Object.keys(roots).length === 0) return
-    await redis.hset(this.name, roots)
+    await this.redis.hset(this.name, roots)
   }
 
   async remove(indices: string[]) {
     if (indices.length === 0) return
-    await redis.hdel(this.name, indices)
+    await this.redis.hdel(this.name, indices)
   }
 
   async get(index: string) {
-    return redis.hget(this.name, index)
+    return this.redis.hget(this.name, index)
   }
 
   async clear() {
-    await redis.del(this.name)
+    await this.redis.del(this.name)
   }
 }

--- a/zp-relayer/test/pool.test.ts
+++ b/zp-relayer/test/pool.test.ts
@@ -1,30 +1,27 @@
 import { expect } from 'chai'
-import { decodeMemo } from 'zp-memo-parser/memo'
-import { MerkleTree, Constants, Helpers } from 'libzkbob-rs-node'
-import depositMemo from './depositMemo.json'
-import fs from 'fs'
-import { TxType } from 'zp-memo-parser'
-
-const DB_PATH = './test-tree.db'
+import { EIP1559GasPriceWithinLimit } from '../services/gas-price/GasPrice'
+import { toBN } from 'web3-utils'
 
 describe('Pool', () => {
-  it('calculates out commit', () => {
-    const tree = new MerkleTree(DB_PATH)
+  it('correctly calculates fee limit', () => {
+    const fees = {
+      maxFeePerGas: '15',
+      maxPriorityFeePerGas: '7',
+    }
 
-    const buf = Buffer.from(depositMemo, 'hex')
-    const memo = decodeMemo(buf, TxType.DEPOSIT)
+    expect(EIP1559GasPriceWithinLimit(fees, toBN(100))).to.deep.equal({
+      maxFeePerGas: '15',
+      maxPriorityFeePerGas: '7',
+    })
 
-    tree.appendHash(Buffer.from(memo.accHash))
-    memo.noteHashes.forEach(n => tree.appendHash(Buffer.from(n)))
+    expect(EIP1559GasPriceWithinLimit(fees, toBN(10))).to.deep.equal({
+      maxFeePerGas: '10',
+      maxPriorityFeePerGas: '2',
+    })
 
-    // Commit calculated from raw hashes
-    const hashes = [memo.accHash].concat(memo.noteHashes).map(Buffer.from)
-    const out_commit_calc = Helpers.outCommitmentHash(hashes)
-    // Commit as a root of subtree with inserted hashes
-    const out_commit_node = tree.getNode(Constants.OUTLOG, 0)
-
-    expect(out_commit_calc).eq(out_commit_node)
-
-    fs.rmdirSync(DB_PATH, { recursive: true })
+    expect(EIP1559GasPriceWithinLimit(fees, toBN(6))).to.deep.equal({
+      maxFeePerGas: '6',
+      maxPriorityFeePerGas: '0',
+    })
   })
 })

--- a/zp-relayer/test/pool.test.ts
+++ b/zp-relayer/test/pool.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
-import { EIP1559GasPriceWithinLimit } from '../services/gas-price/GasPrice'
 import { toBN } from 'web3-utils'
+import { EIP1559GasPriceWithinLimit } from '../services/gas-price/GasPrice'
+import { checkDeadline } from '../validateTx'
 
 describe('Pool', () => {
   it('correctly calculates fee limit', () => {
@@ -9,19 +10,26 @@ describe('Pool', () => {
       maxPriorityFeePerGas: '7',
     }
 
-    expect(EIP1559GasPriceWithinLimit(fees, toBN(100))).to.deep.equal({
+    expect(EIP1559GasPriceWithinLimit(fees, toBN(100))).to.eql({
       maxFeePerGas: '15',
       maxPriorityFeePerGas: '7',
     })
 
-    expect(EIP1559GasPriceWithinLimit(fees, toBN(10))).to.deep.equal({
+    expect(EIP1559GasPriceWithinLimit(fees, toBN(10))).to.eql({
       maxFeePerGas: '10',
       maxPriorityFeePerGas: '7',
     })
 
-    expect(EIP1559GasPriceWithinLimit(fees, toBN(6))).to.deep.equal({
+    expect(EIP1559GasPriceWithinLimit(fees, toBN(6))).to.eql({
       maxFeePerGas: '6',
       maxPriorityFeePerGas: '6',
     })
+  })
+  it('correctly checks deadline', () => {
+    // curent time + 10 sec
+    const signedDeadline = toBN(Math.floor(Date.now() / 1000) + 10)
+
+    expect(checkDeadline(signedDeadline, 7)).to.be.null
+    expect(checkDeadline(signedDeadline, 11)).to.be.instanceOf(Error)
   })
 })

--- a/zp-relayer/test/pool.test.ts
+++ b/zp-relayer/test/pool.test.ts
@@ -16,12 +16,12 @@ describe('Pool', () => {
 
     expect(EIP1559GasPriceWithinLimit(fees, toBN(10))).to.deep.equal({
       maxFeePerGas: '10',
-      maxPriorityFeePerGas: '2',
+      maxPriorityFeePerGas: '7',
     })
 
     expect(EIP1559GasPriceWithinLimit(fees, toBN(6))).to.deep.equal({
       maxFeePerGas: '6',
-      maxPriorityFeePerGas: '0',
+      maxPriorityFeePerGas: '6',
     })
   })
 })

--- a/zp-relayer/utils/redisFields.ts
+++ b/zp-relayer/utils/redisFields.ts
@@ -41,6 +41,10 @@ export function updateField(key: RelayerKeys, val: any) {
   return redis.set(key, val)
 }
 
+export function updateNonce(nonce: number) {
+  return updateField(RelayerKeys.NONCE, nonce)
+}
+
 export async function incrNonce() {
   const nonce = await redis.incr(RelayerKeys.NONCE)
   logger.info(`Incremented nonce to ${nonce}`)

--- a/zp-relayer/utils/web3Errors.ts
+++ b/zp-relayer/utils/web3Errors.ts
@@ -1,0 +1,25 @@
+export function isGasPriceError(e: Error) {
+  const message = e.message.toLowerCase()
+  return message.includes('replacement transaction underpriced')
+}
+
+export function isSameTransactionError(e: Error) {
+  const message = e.message.toLowerCase()
+  return (
+    message.includes('transaction with the same hash was already imported') ||
+    message.includes('already known') ||
+    message.includes('alreadyknown') ||
+    message.includes('transaction already imported')
+  )
+}
+
+export function isNonceError(e: Error) {
+  const message = e.message.toLowerCase()
+  return (
+    message.includes('transaction nonce is too low') ||
+    message.includes('nonce too low') ||
+    message.includes('transaction with same nonce in the queue') ||
+    message.includes('oldnonce') ||
+    message.includes(`the tx doesn't have the correct nonce`)
+  )
+}

--- a/zp-relayer/validateTx.ts
+++ b/zp-relayer/validateTx.ts
@@ -178,8 +178,6 @@ async function getRecoveredAddress(
       salt: nullifier,
     }
     recoveredAddress = recoverSaltedPermit(message, sig)
-
-    await checkAssertion(() => checkDeadline(deadline))
   } else {
     throw new Error('Unsupported txtype')
   }
@@ -233,7 +231,13 @@ export async function validateTx({ txType, rawMemo, txProof, depositSignature }:
     userAddress = await getRecoveredAddress(txType, nullifier, txData, requiredTokenAmount, depositSignature)
     await checkAssertion(() => checkDepositEnoughBalance(userAddress, requiredTokenAmount))
   }
+  if (txType === TxType.PERMITTABLE_DEPOSIT) {
+    const deadline = (txData as PermittableDepositTxData).deadline
+    await checkAssertion(() => checkDeadline(deadline))
+  }
 
   const limits = await pool.getLimitsFor(userAddress)
   await checkAssertion(() => checkLimits(limits, delta.tokenAmount))
+
+  return txData
 }

--- a/zp-relayer/workers/poolTxWorker.ts
+++ b/zp-relayer/workers/poolTxWorker.ts
@@ -37,7 +37,7 @@ export async function createPoolTxWorker<T extends EstimationType>(gasPrice: Gas
     for (const tx of txs) {
       const { gas, amount, rawMemo, txType, txProof } = tx
 
-      await validateTx(tx)
+      const txData = await validateTx(tx)
 
       const { data, commitIndex, rootAfter } = await processTx(job.id as string, tx)
 
@@ -70,9 +70,9 @@ export async function createPoolTxWorker<T extends EstimationType>(gasPrice: Gas
         const outCommit = getTxProofField(txProof, 'out_commit')
 
         const truncatedMemo = truncateMemoTxPrefix(rawMemo, txType)
-        const txData = numToHex(toBN(outCommit)).concat(txHash.slice(2)).concat(truncatedMemo)
+        const prefixedMemo = numToHex(toBN(outCommit)).concat(txHash.slice(2)).concat(truncatedMemo)
 
-        pool.optimisticState.updateState(commitIndex, outCommit, txData)
+        pool.optimisticState.updateState(commitIndex, outCommit, prefixedMemo)
         logger.debug('Adding nullifier %s to OS', nullifier)
         await pool.optimisticState.nullifiers.add([nullifier])
         const poolIndex = (commitIndex + 1) * OUTPLUSONE
@@ -86,14 +86,16 @@ export async function createPoolTxWorker<T extends EstimationType>(gasPrice: Gas
         await sentTxQueue.add(
           txHash,
           {
+            txType,
             root: rootAfter,
             outCommit,
             commitIndex,
             txHash,
-            txData,
+            prefixedMemo,
             nullifier,
             txConfig,
             gasPriceOptions,
+            txData,
           },
           {
             delay: config.sentTxDelay,

--- a/zp-relayer/workers/poolTxWorker.ts
+++ b/zp-relayer/workers/poolTxWorker.ts
@@ -37,7 +37,7 @@ export async function createPoolTxWorker<T extends EstimationType>(gasPrice: Gas
     for (const tx of txs) {
       const { gas, amount, rawMemo, txType, txProof } = tx
 
-      const txData = await validateTx(tx)
+      const txData = await validateTx(tx, pool)
 
       const { data, commitIndex, rootAfter } = await processTx(job.id as string, tx)
 

--- a/zp-relayer/workers/poolTxWorker.ts
+++ b/zp-relayer/workers/poolTxWorker.ts
@@ -4,7 +4,7 @@ import { web3 } from '@/services/web3'
 import { logger } from '@/services/appLogger'
 import { TxPayload } from '@/queue/poolTxQueue'
 import { TX_QUEUE_NAME, OUTPLUSONE, MAX_SENT_LIMIT } from '@/utils/constants'
-import { readNonce, updateField, RelayerKeys, incrNonce } from '@/utils/redisFields'
+import { readNonce, updateField, RelayerKeys, incrNonce, updateNonce } from '@/utils/redisFields'
 import { numToHex, truncateMemoTxPrefix, withErrorLog, withMutex } from '@/utils/helpers'
 import { signAndSend } from '@/tx/signAndSend'
 import { pool } from '@/pool'
@@ -114,7 +114,7 @@ export async function createPoolTxWorker<T extends EstimationType>(gasPrice: Gas
     return txHashes
   }
 
-  await updateField(RelayerKeys.NONCE, await readNonce(true))
+  await updateNonce(await readNonce(true))
   const poolTxWorker = new Worker<TxPayload[]>(
     TX_QUEUE_NAME,
     job => withErrorLog(withMutex(mutex, () => poolTxWorkerProcessor(job))),

--- a/zp-relayer/workers/sentTxWorker.ts
+++ b/zp-relayer/workers/sentTxWorker.ts
@@ -136,7 +136,7 @@ export async function createSentTxWorker<T extends EstimationType>(gasPrice: Gas
       // Resend with updated gas price
       if (txType === TxType.PERMITTABLE_DEPOSIT) {
         const deadline = (txData as PermittableDepositTxData).deadline
-        await checkAssertion(() => checkDeadline(deadline))
+        await checkAssertion(() => checkDeadline(deadline, config.permitDeadlineThresholdResend))
       }
 
       const txConfig = job.data.txConfig


### PR DESCRIPTION
Closes #35 
Added assertion for permit deadline when resending a transaction.
https://github.com/zkBob/zeropool-relayer/blob/68e93a906abc45469a7be9f541f04d6c5bb3f728/zp-relayer/workers/sentTxWorker.ts#L137-L140

Closes #49 
Added handling of some client errors when resending a transaction.
https://github.com/zkBob/zeropool-relayer/blob/68e93a906abc45469a7be9f541f04d6c5bb3f728/zp-relayer/workers/sentTxWorker.ts#L177
https://github.com/zkBob/zeropool-relayer/blob/68e93a906abc45469a7be9f541f04d6c5bb3f728/zp-relayer/workers/sentTxWorker.ts#L180

Closes #51 
Gas price is updated if corresponding error was thrown during transaction re-send. Related to #49 

Closes #52 
See #77 

Closes #74 
Implemented proper transaction re-send mechanism. Re-send errors related to gasPrice/nonce are handled. Other errors are considered as unrecoverable, and in this case optimistic state rollback is performed.
https://github.com/zkBob/zeropool-relayer/blob/68e93a906abc45469a7be9f541f04d6c5bb3f728/zp-relayer/workers/sentTxWorker.ts#L183-L187

Closes #77 
Added `MAX_FEE_PER_GAS_LIMIT` env variable for limiting max value of `maxFeePerGas`.
Gas parameters are calculated as follows:
`new_maxFeePerGas = min(MAX_FEE_PER_GAS_LIMIT, old_maxFeePerGas)`
`new_maxPriorityFeePerGas = max(0, old_maxPriorityFeePerGas - (old_maxFeePerGas - MAX_FEE_PER_GAS_LIMIT))` 
This behaviour is described in tests.