### PR TITLE
Bump package version to 2.0.0

### DIFF
--- a/zp-relayer/package.json
+++ b/zp-relayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zp-relayer",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {


### PR DESCRIPTION
The major version has been increased since `/proof_tx` API-endpoint is not available starting from #59