### PR TITLE
Fix/updated hash

### DIFF
--- a/zp-relayer/endpoints.ts
+++ b/zp-relayer/endpoints.ts
@@ -118,6 +118,7 @@ async function getJob(req: Request, res: Response) {
   }
 
   interface GetJobResponse {
+    resolvedJobId: string
     createdOn: number
     failedReason: null | string
     finishedOn: null | number
@@ -134,6 +135,7 @@ async function getJob(req: Request, res: Response) {
 
     // Default result object
     let result: GetJobResponse = {
+      resolvedJobId: jobId,
       createdOn: job.timestamp,
       failedReason: null,
       finishedOn: null,

--- a/zp-relayer/endpoints.ts
+++ b/zp-relayer/endpoints.ts
@@ -112,7 +112,7 @@ async function getJob(req: Request, res: Response) {
   enum JobStatus {
     WAITING = 'waiting',
     FAILED = 'failed',
-    SENDED = 'sended',
+    SENT = 'sent',
     REVERTED = 'reverted',
     COMPLETED = 'completed',
   }
@@ -153,7 +153,7 @@ async function getJob(req: Request, res: Response) {
       if (sentJobState === 'waiting' || sentJobState === 'active' || sentJobState === 'delayed') {
         // Transaction is in re-send loop
         const txHash = sentJob.data.prevAttempts.at(-1)?.[0]
-        result.state = JobStatus.SENDED
+        result.state = JobStatus.SENT
         result.txHash = txHash || null
       } else if (sentJobState === 'completed') {
         const [txState, txHash] = sentJob.returnvalue

--- a/zp-relayer/endpoints.ts
+++ b/zp-relayer/endpoints.ts
@@ -127,7 +127,8 @@ async function getJob(req: Request, res: Response) {
 
   const jobId = req.params.id
 
-  async function getPoolJobState(jobId: string): Promise<GetJobResponse | null> {
+  async function getPoolJobState(requestedJobId: string): Promise<GetJobResponse | null> {
+    const jobId = await pool.state.jobIdsMapping.get(requestedJobId)
     const job = await poolTxQueue.getJob(jobId)
     if (!job) return null
 

--- a/zp-relayer/endpoints.ts
+++ b/zp-relayer/endpoints.ts
@@ -11,6 +11,7 @@ import {
   checkSendTransactionErrors,
   checkSendTransactionsErrors,
 } from './validation/validation'
+import { sentTxQueue, SentTxState } from './queue/sentTxQueue'
 
 async function sendTransactions(req: Request, res: Response, next: NextFunction) {
   const errors = checkSendTransactionsErrors(req.body)
@@ -108,22 +109,81 @@ async function getTransactionsV2(req: Request, res: Response, next: NextFunction
 }
 
 async function getJob(req: Request, res: Response) {
-  const jobId = req.params.id
-  const job = await poolTxQueue.getJob(jobId)
-  if (job) {
-    const state = await job.getState()
-    const txHash = job.returnvalue
-    const failedReason = job.failedReason
-    const createdOn = job.timestamp
-    const finishedOn = job.finishedOn
+  enum JobStatus {
+    WAITING = 'waiting',
+    FAILED = 'failed',
+    SENDED = 'sended',
+    REVERTED = 'reverted',
+    COMPLETED = 'completed',
+  }
 
-    res.json({
-      state,
-      txHash,
-      failedReason,
-      createdOn,
-      finishedOn,
-    })
+  interface GetJobResponse {
+    createdOn: number
+    failedReason: null | string
+    finishedOn: null | number
+    state: JobStatus
+    txHash: null | string
+  }
+
+  const jobId = req.params.id
+
+  async function getPoolJobState(jobId: string): Promise<GetJobResponse | null> {
+    const job = await poolTxQueue.getJob(jobId)
+    if (!job) return null
+
+    // Default result object
+    let result: GetJobResponse = {
+      createdOn: job.timestamp,
+      failedReason: null,
+      finishedOn: null,
+      state: JobStatus.WAITING,
+      txHash: null,
+    }
+
+    const poolJobState = await job.getState()
+    if (poolJobState === 'completed') {
+      // Transaction was included in optimistic state, waiting to be mined
+      const sentJobId = job.returnvalue[0][1]
+      const sentJob = await sentTxQueue.getJob(sentJobId)
+      // Should not happen here, but need to verify to be sure
+      if (!sentJob) throw new Error('Sent job not found')
+
+      const sentJobState = await sentJob.getState()
+      if (sentJobState === 'waiting' || sentJobState === 'active' || sentJobState === 'delayed') {
+        // Transaction is in re-send loop
+        const txHash = sentJob.data.prevAttempts.at(-1)?.[0]
+        result.state = JobStatus.SENDED
+        result.txHash = txHash || null
+      } else if (sentJobState === 'completed') {
+        const [txState, txHash] = sentJob.returnvalue
+        if (txState === SentTxState.MINED) {
+          // Transaction mined successfully
+          result.state = JobStatus.COMPLETED
+          result.txHash = txHash
+          result.finishedOn = sentJob.finishedOn || null
+        } else if (txState === SentTxState.REVERT) {
+          // Transaction reverted
+          result.state = JobStatus.REVERTED
+          result.txHash = txHash
+          result.finishedOn = sentJob.finishedOn || null
+        }
+      }
+    } else if (poolJobState === 'failed') {
+      // Either validation or tx sendind failed
+      result.state = JobStatus.FAILED
+      result.failedReason = job.failedReason
+      result.finishedOn = job.finishedOn || null
+    }
+    // Other states mean that transaction is either waiting in queue
+    // or being processed by worker
+    // So, no need to update `result` object
+
+    return result
+  }
+
+  const jobState = await getPoolJobState(jobId)
+  if (jobState) {
+    res.json(jobState)
   } else {
     res.json(`Job ${jobId} not found`)
   }

--- a/zp-relayer/queue/sentTxQueue.ts
+++ b/zp-relayer/queue/sentTxQueue.ts
@@ -7,6 +7,7 @@ import { TxPayload } from './poolTxQueue'
 
 export type SendAttempt = [string, GasPriceValue]
 export interface SentTxPayload {
+  poolJobId: string
   root: string
   outCommit: string
   commitIndex: number

--- a/zp-relayer/queue/sentTxQueue.ts
+++ b/zp-relayer/queue/sentTxQueue.ts
@@ -11,7 +11,7 @@ export interface SentTxPayload {
   root: string
   outCommit: string
   commitIndex: number
-  prefixedMemo: string
+  truncatedMemo: string
   txConfig: TransactionConfig
   nullifier: string
   txPayload: TxPayload

--- a/zp-relayer/state/PoolState.ts
+++ b/zp-relayer/state/PoolState.ts
@@ -4,18 +4,23 @@ import { OUTPLUSONE } from '@/utils/constants'
 import { MerkleTree, TxStorage, MerkleProof, Constants, Helpers } from 'libzkbob-rs-node'
 import { NullifierSet } from './nullifierSet'
 import { RootSet } from './rootSet'
+import { JobIdsMapping } from './jobIdsMapping'
 
 export class PoolState {
   private tree: MerkleTree
   private txs: TxStorage
   public nullifiers: NullifierSet
   public roots: RootSet
+  public jobIdsMapping: JobIdsMapping
 
   constructor(private name: string, redis: Redis, path: string) {
     this.tree = new MerkleTree(`${path}/${name}Tree.db`)
     this.txs = new TxStorage(`${path}/${name}Txs.db`)
     this.nullifiers = new NullifierSet(`${name}-nullifiers`, redis)
     this.roots = new RootSet(`${name}-roots`, redis)
+    // This structure can be shared among different pool states
+    // So, use constant name
+    this.jobIdsMapping = new JobIdsMapping('job-id-mapping', redis)
   }
 
   getVirtualTreeProofInputs(outCommit: string, transferNum?: number) {

--- a/zp-relayer/state/jobIdsMapping.ts
+++ b/zp-relayer/state/jobIdsMapping.ts
@@ -1,0 +1,28 @@
+import type { Redis } from 'ioredis'
+
+export class JobIdsMapping {
+  constructor(public name: string, private redis: Redis) {}
+
+  async add(mapping: Record<string, string>) {
+    if (Object.keys(mapping).length === 0) return
+    await this.redis.hset(this.name, mapping)
+  }
+
+  async remove(indices: string[]) {
+    if (indices.length === 0) return
+    await this.redis.hdel(this.name, ...indices)
+  }
+
+  async get(id: string): Promise<string> {
+    const mappedId = await this.redis.hget(this.name, id)
+    if (mappedId) {
+      return await this.get(mappedId)
+    } else {
+      return id
+    }
+  }
+
+  async clear() {
+    await this.redis.del(this.name)
+  }
+}

--- a/zp-relayer/utils/helpers.ts
+++ b/zp-relayer/utils/helpers.ts
@@ -92,6 +92,10 @@ export function flattenProof(p: SnarkProof): string {
     .join('')
 }
 
+export function buildPrefixedMemo(outCommit: string, txHash: string, truncatedMemo: string) {
+  return numToHex(toBN(outCommit)).concat(txHash.slice(2)).concat(truncatedMemo)
+}
+
 export async function setIntervalAndRun(f: () => Promise<void> | void, interval: number) {
   const handler = setInterval(f, interval)
   await f()

--- a/zp-relayer/utils/helpers.ts
+++ b/zp-relayer/utils/helpers.ts
@@ -4,6 +4,7 @@ import { logger } from '@/services/appLogger'
 import { SnarkProof } from 'libzkbob-rs-node'
 import { TxType } from 'zp-memo-parser'
 import type { Mutex } from 'async-mutex'
+import { TxValidationError } from '@/validateTx'
 
 const S_MASK = toBN('0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
 const S_MAX = toBN('0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0')
@@ -112,7 +113,11 @@ export async function withErrorLog<R>(f: () => Promise<R>): Promise<R> {
   try {
     return await f()
   } catch (e) {
-    logger.error('Found error: %s', (e as Error).message)
+    if (e instanceof TxValidationError) {
+      logger.warn('Validation error: %s', (e as Error).message)
+    } else {
+      logger.error('Found error: %s', (e as Error).message)
+    }
     throw e
   }
 }

--- a/zp-relayer/validateTx.ts
+++ b/zp-relayer/validateTx.ts
@@ -161,7 +161,7 @@ async function getRecoveredAddress(
   // Signature without `0x` prefix, size is 64*2=128
   await checkAssertion(() => {
     if (depositSignature !== null && checkSize(depositSignature, 128)) return null
-    return new TxValidationError('Invalid deposit signature')
+    return new TxValidationError('Invalid deposit signature size')
   })
   const nullifier = '0x' + numToHex(toBN(proofNullifier))
   const sig = unpackSignature(depositSignature as string)
@@ -184,6 +184,9 @@ async function getRecoveredAddress(
       salt: nullifier,
     }
     recoveredAddress = recoverSaltedPermit(message, sig)
+    if (recoveredAddress.toLowerCase() !== owner.toLowerCase()) {
+      throw new TxValidationError(`Invalid deposit signer; Restored: ${recoveredAddress}; Expected: ${owner}`)
+    }
   } else {
     throw new TxValidationError('Unsupported txtype')
   }

--- a/zp-relayer/workers/poolTxWorker.ts
+++ b/zp-relayer/workers/poolTxWorker.ts
@@ -100,6 +100,7 @@ export async function createPoolTxWorker<T extends EstimationType>(
         const sentJob = await sentTxQueue.add(
           txHash,
           {
+            poolJobId: job.id as string,
             root: rootAfter,
             outCommit,
             commitIndex,

--- a/zp-relayer/workers/poolTxWorker.ts
+++ b/zp-relayer/workers/poolTxWorker.ts
@@ -78,7 +78,7 @@ export async function createPoolTxWorker<T extends EstimationType>(
 
         await updateNonce(++nonce)
 
-        logger.debug(`${logPrefix} TX hash ${txHash}`)
+        logger.info(`${logPrefix} TX hash ${txHash}`)
 
         await updateField(RelayerKeys.TRANSFER_NUM, commitIndex * OUTPLUSONE)
 

--- a/zp-relayer/workers/sentTxWorker.ts
+++ b/zp-relayer/workers/sentTxWorker.ts
@@ -100,7 +100,7 @@ export async function createSentTxWorker<T extends EstimationType>(gasPrice: Gas
       // Tx mined
       if (tx.status) {
         // Successful
-        logger.debug('%s Transaction %s was successfully mined at block %s', logPrefix, txHash, tx.blockNumber)
+        logger.info('%s Transaction %s was successfully mined at block %s', logPrefix, txHash, tx.blockNumber)
 
         pool.state.updateState(commitIndex, outCommit, prefixedMemo)
 
@@ -183,6 +183,7 @@ export async function createSentTxWorker<T extends EstimationType>(gasPrice: Gas
       job.data.prevAttempts.push([newTxHash, newGasPrice])
       try {
         await sendTransaction(web3, rawTransaction)
+        logger.info(`${logPrefix} Re-send tx; New hash: ${newTxHash}`)
       } catch (e) {
         const err = e as Error
         logger.warn('%s Tx resend failed for %s: %s', logPrefix, lastHash, err.message)


### PR DESCRIPTION
Updates:
* Fix minor logging issues found after deploying on staging:
    1. Validation errors now are considered as warnings
    2. Changed `debug` level to `info` in some places
    3. Added log for re-sent transaction hash (Closes #89)
* Enhance signature validation (Closes #95). Compare recovered address with owner field from memo. If these addresses mismatch, the we don't need to check token balance and can throw a corresponding error.
* Update job status model with following statuses: `waiting`, `failed`, `sent`, `reverted`, `completed`. Description:
    `waiting` - job is waiting in queue or being processed by `poolTxWorker`
    `failed` - job failed validation step before it was submitted to contract
    `sent` - job is being processed by `sentTxWorker`
    `reverted` - job got a confirmed revert
    `completed` - job completed successfully
    Expected `/job/:id` response type for each status:
    * `waiting`: 
        ```ts
        {
            createdOn: number
            failedReason: null
            finishedOn: null
            state: "waiting"
            txHash: null
        }
        ```
    * `failed`:
        ```ts
        {
            createdOn: number
            failedReason: string
            finishedOn: number
            state: "failed"
            txHash: null
        }
        ```
    * `sendt`:
        ```ts
        {
            createdOn: number
            failedReason: null
            finishedOn: null
            state: "sent"
            txHash: string
        }
        ```
    * `reverted`:
        ```ts
        {
            createdOn: number
            failedReason: null
            finishedOn: number
            state: "reverted"
            txHash: string
        }
        ```
    * `completed`:
        ```ts
        {
            createdOn: number
            failedReason: null
            finishedOn: number
            state: "completed"
            txHash: string
        }
        ```
* Added `JobIdsMapping`. It is required to track statuses of re-submitted to `poolTxQueue` failed jobs. After job is re-submitted back to the queue, a new record is stored in redis linking original pool job id to the new one.
* Update transaction hash in optimistic state after transaction re-send (Closes #81)