### PR TITLE
Bump package version to 3.0.0

### DIFF
--- a/zp-relayer/package.json
+++ b/zp-relayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zp-relayer",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {

--- a/zp-relayer/package.json
+++ b/zp-relayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zp-relayer",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {


### PR DESCRIPTION
The major version was increased since there is no backward compatibility anymore -- the endpoints `sendTransaction` and `transactions` were removed as part of #121