### PR TITLE
Add optional RPC sync check

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -29,6 +29,7 @@
 | RELAYER_REDIS_URL | Url to redis instance | URL |
 | RPC_URL | The HTTPS URL(s) used to communicate to the RPC nodes. Several URLs can be specified, delimited by spaces. If the connection to one of these nodes is lost the next URL is used for connection. | URL |
 | RELAYER_TX_REDUNDANCY | If set to `true`, instructs relayer to send `eth_sendRawTransaction` requests through all available RPC urls defined in `RPC_URL` variables instead of using first available one. Defaults to `false` | boolean |
+| RELAYER_RPC_SYNC_STATE_CHECK_INTERVAL | Interval for checking JSON RPC sync state, by requesting the latest block number. Relayer will switch to the fallback JSON RPC in case sync process is stuck. If this variable is `0` sync state check is disabled. Defaults to `0`  | integer |
 | SENT_TX_DELAY | Delay in milliseconds for sentTxWorker to verify submitted transactions | integer |
 | PERMIT_DEADLINE_THRESHOLD_INITIAL | Minimum time threshold in seconds for permit signature deadline to be valid (before initial transaction submission) | integer |
 | PERMIT_DEADLINE_THRESHOLD_RESEND | Minimum time threshold in seconds for permit signature deadline to be valid (for re-send attempts) | integer |

--- a/zp-relayer/config.ts
+++ b/zp-relayer/config.ts
@@ -37,6 +37,7 @@ const config = {
   relayerTxRedundancy: process.env.RELAYER_TX_REDUNDANCY === 'true',
   sentTxDelay: parseInt(process.env.SENT_TX_DELAY || '30000'),
   rpcRequestTimeout: parseInt(process.env.RPC_REQUEST_TIMEOUT || '1000'),
+  rpcSyncCheckInterval: parseInt(process.env.RELAYER_RPC_SYNC_STATE_CHECK_INTERVAL || '0'),
   permitDeadlineThresholdInitial: parseInt(process.env.PERMIT_DEADLINE_THRESHOLD_INITIAL || '300'),
   relayerJsonRpcErrorCodes: (process.env.RELAYER_JSONRPC_ERROR_CODES || '-32603,-32002,-32005')
     .split(',')

--- a/zp-relayer/services/providers/HttpListProvider.ts
+++ b/zp-relayer/services/providers/HttpListProvider.ts
@@ -1,5 +1,6 @@
 // Reference implementation:
 // https://github.com/omni/tokenbridge/blob/master/oracle/src/services/HttpListProvider.js
+import { hexToNumber } from 'web3-utils'
 import promiseRetry from 'promise-retry'
 import { FALLBACK_RPC_URL_SWITCH_TIMEOUT } from '@/utils/constants'
 import { logger } from '../appLogger'
@@ -17,6 +18,8 @@ export default class HttpListProvider extends BaseHttpProvider {
   urls: string[]
   currentIndex: number
   lastTimeUsedPrimary: number
+  latestBlock: number
+  syncStateCheckerIntervalId?: NodeJS.Timer
 
   constructor(urls: string[], options: Partial<ProviderOptions> = {}) {
     if (!urls || !urls.length) {
@@ -26,11 +29,54 @@ export default class HttpListProvider extends BaseHttpProvider {
     super(urls[0], options)
     this.currentIndex = 0
     this.lastTimeUsedPrimary = 0
+    this.latestBlock = 0
 
     this.urls = urls
   }
 
-  private updateUrlIndex(index: number) {
+  startSyncStateChecker(syncCheckInterval: number) {
+    if (this.urls.length > 1 && syncCheckInterval > 0 && !this.syncStateCheckerIntervalId) {
+      this.syncStateCheckerIntervalId = setInterval(() => this.checkLatestBlock(), syncCheckInterval)
+    }
+  }
+
+  checkLatestBlock() {
+    const payload = { jsonrpc: '2.0', id: 1, method: 'eth_blockNumber', params: [] }
+    this.send(payload, (error: any, result: any) => {
+      if (error) {
+        logger.warn('Failed to request latest block from all RPC urls', { oldBlock: this.latestBlock })
+      } else if (result.error) {
+        logger.warn('Failed to make eth_blockNumber request due to unknown error', {
+          oldBlock: this.latestBlock,
+          error: result.error.message,
+        })
+        this.updateUrlIndex()
+      } else {
+        const blockNumber = hexToNumber(result.result)
+        const blocksLog = { oldBlock: this.latestBlock, newBlock: blockNumber }
+        if (blockNumber > this.latestBlock) {
+          logger.debug('Updating latest block number', blocksLog)
+          this.latestBlock = blockNumber
+        } else {
+          logger.warn('Latest block on the node was not updated since last request', blocksLog)
+          this.updateUrlIndex()
+        }
+      }
+    })
+  }
+
+  private updateUrlIndex(index?: number) {
+    const prevIndex = this.currentIndex
+    if (!index) {
+      index = (prevIndex + 1) % this.urls.length
+    }
+
+    if (prevIndex === index) {
+      return
+    }
+
+    logger.info('Switching JSON-RPC URL: %s -> %s; Index: %d', this.urls[this.currentIndex], this.urls[index], index)
+
     this.currentIndex = index
     this.host = this.urls[this.currentIndex]
   }
@@ -53,12 +99,6 @@ export default class HttpListProvider extends BaseHttpProvider {
 
       // if some of URLs failed to respond, current URL index is updated to the first URL that responded
       if (currentIndex !== index) {
-        logger.info(
-          'Switching to fallback JSON-RPC URL: %s -> %s; Index: %d',
-          this.urls[this.currentIndex],
-          this.urls[index],
-          index
-        )
         this.updateUrlIndex(index)
       }
       callback(null, result)

--- a/zp-relayer/services/web3.ts
+++ b/zp-relayer/services/web3.ts
@@ -11,6 +11,7 @@ const providerOptions = {
 }
 
 const provider = new HttpListProvider(config.rpcUrls, providerOptions)
+provider.startSyncStateChecker(config.rpcSyncCheckInterval)
 const web3 = new Web3(provider as HttpProvider)
 
 let web3Redundant = web3


### PR DESCRIPTION
Changes:
* Add optional periodic RPC sync check similar to [tokenbridge](https://github.com/omni/tokenbridge/blob/961b12b9f3545830a04044e109762277efcea6ef/oracle/src/services/HttpListProvider.js#L51). Interval can be set via `RELAYER_RPC_SYNC_STATE_CHECK_INTERVAL` env (in milliseconds). If the env is not set sync check is disabled by default.
Closes #46 