### PR TITLE
Fix events block range

### DIFF
--- a/zp-relayer/pool.ts
+++ b/zp-relayer/pool.ts
@@ -17,7 +17,7 @@ import { PoolState } from './state/PoolState'
 import { TxType } from 'zp-memo-parser'
 import { numToHex, toTxType, truncateHexPrefix, truncateMemoTxPrefix } from './utils/helpers'
 import { PoolCalldataParser } from './utils/PoolCalldataParser'
-import { INIT_ROOT, OUTPLUSONE } from './utils/constants'
+import { OUTPLUSONE } from './utils/constants'
 
 export interface PoolTx {
   proof: Proof
@@ -130,8 +130,8 @@ class Pool {
     return lastBlockNumber
   }
 
-  async syncState(fromBlock: number) {
-    logger.debug('Syncing state; starting from block %d', fromBlock)
+  async syncState(startBlock: number) {
+    logger.debug('Syncing state; starting from block %d', startBlock)
 
     const localIndex = this.state.getNextIndex()
     const localRoot = this.state.getMerkleRoot()
@@ -154,12 +154,12 @@ class Pool {
     }
 
     const lastBlockNumber = await this.getLastBlockToProcess()
-    let finishBlock = fromBlock
-    for (let startBlock = fromBlock; finishBlock <= lastBlockNumber; startBlock = finishBlock) {
-      finishBlock += config.eventsProcessingBatchSize
+    let toBlock = startBlock
+    for (let fromBlock = startBlock; toBlock <= lastBlockNumber + 1; startBlock = toBlock) {
+      toBlock += config.eventsProcessingBatchSize
       const events = await getEvents(this.PoolInstance, 'Message', {
-        fromBlock: startBlock,
-        toBlock: finishBlock,
+        fromBlock,
+        toBlock: toBlock - 1,
         filter: {
           index: missedIndices,
         },


### PR DESCRIPTION
Changes:
* Fix block range for `getEvents`. Example range requests for `BATCH_SIZE=10000`: `(0..9999)`, `(10000..19999)`, `(20000..29999)`. Previously it was: `(0..10000)`, `(10000..20000)`, `(20000..30000)`.
Closes #125 