### PR TITLE
Add iteration count to sent worker; Fix log levels

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -32,6 +32,7 @@
 | RELAYER_RPC_SYNC_STATE_CHECK_INTERVAL | Interval in milliseconds for checking JSON RPC sync state, by requesting the latest block number. Relayer will switch to the fallback JSON RPC in case sync process is stuck. If this variable is `0` sync state check is disabled. Defaults to `0`  | integer |
 | INSUFFICIENT_BALANCE_CHECK_TIMEOUT | Interval in milliseconds to check for relayer balance update if transaction send failed with insufficient balance error. Default `60000` | integer |
 | SENT_TX_DELAY | Delay in milliseconds for sentTxWorker to verify submitted transactions | integer |
+| SENT_TX_ERROR_THRESHOLD | Maximum number of re-sends which is considered to be normal. After this threshold each re-send will log a corresponding error (but re-send loop will continue). Defaults to `3`. | integer |
 | PERMIT_DEADLINE_THRESHOLD_INITIAL | Minimum time threshold in seconds for permit signature deadline to be valid (before initial transaction submission) | integer |
 | PERMIT_DEADLINE_THRESHOLD_RESEND | Minimum time threshold in seconds for permit signature deadline to be valid (for re-send attempts) | integer |
 | RELAYER_REQUIRE_TRACE_ID | If set to `true`, then requests to relayer (except `/info`, `/version`, `/params/hash/tree`, `/params/hash/tx`) without `zkbob-support-id` header will be rejected. | boolean |

--- a/zp-relayer/config.ts
+++ b/zp-relayer/config.ts
@@ -38,6 +38,7 @@ const config = {
   rpcUrls: (process.env.RPC_URL as string).split(' ').filter(url => url.length > 0),
   relayerTxRedundancy: process.env.RELAYER_TX_REDUNDANCY === 'true',
   sentTxDelay: parseInt(process.env.SENT_TX_DELAY || '30000'),
+  sentTxLogErrorThreshold: parseInt(process.env.SENT_TX_ERROR_THRESHOLD || '3'),
   rpcRequestTimeout: parseInt(process.env.RPC_REQUEST_TIMEOUT || '1000'),
   insufficientBalanceCheckTimeout: parseInt(process.env.INSUFFICIENT_BALANCE_CHECK_TIMEOUT || '60000'),
   rpcSyncCheckInterval: parseInt(process.env.RELAYER_RPC_SYNC_STATE_CHECK_INTERVAL || '0'),

--- a/zp-relayer/utils/helpers.ts
+++ b/zp-relayer/utils/helpers.ts
@@ -103,11 +103,14 @@ export async function setIntervalAndRun(f: () => Promise<void> | void, interval:
   return handler
 }
 
-export function withMutex<R>(mutex: Mutex, f: () => Promise<R>): () => Promise<R> {
-  return async () => {
+export function withMutex<F extends (...args: any[]) => any>(
+  mutex: Mutex,
+  f: F
+): (...args: Parameters<F>) => Promise<Awaited<ReturnType<F>>> {
+  return async (...args) => {
     const release = await mutex.acquire()
     try {
-      return await f()
+      return await f(...args)
     } finally {
       release()
     }
@@ -136,12 +139,16 @@ function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-export function withLoop<R>(f: () => Promise<R>, timeout: number, suppressedErrors: string[] = []): () => Promise<R> {
-  // @ts-ignore
+export function withLoop<F extends (i: number) => any>(
+  f: F,
+  timeout: number,
+  suppressedErrors: string[] = []
+): () => Promise<Awaited<ReturnType<F>>> {
   return async () => {
+    let i = 1
     while (1) {
       try {
-        return await f()
+        return await f(i++)
       } catch (e) {
         const err = e as Error
         let isSuppressed = false
@@ -169,7 +176,7 @@ export function waitForFunds(
   address: string,
   cb: (balance: BN) => void,
   minimumBalance: BN,
-  timeout: number,
+  timeout: number
 ) {
   return promiseRetry(
     async retry => {

--- a/zp-relayer/workers/poolTxWorker.ts
+++ b/zp-relayer/workers/poolTxWorker.ts
@@ -141,10 +141,11 @@ export async function createPoolTxWorker<T extends EstimationType>(
 
   const poolTxWorker = new Worker<BatchTx, PoolTxResult[]>(
     TX_QUEUE_NAME,
-    job => withErrorLog(
-      withMutex(mutex, () => poolTxWorkerProcessor(job)),
-      [TxValidationError]
-    ),
+    job =>
+      withErrorLog(
+        withMutex(mutex, () => poolTxWorkerProcessor(job)),
+        [TxValidationError]
+      ),
     WORKER_OPTIONS
   )
 

--- a/zp-relayer/workers/sentTxWorker.ts
+++ b/zp-relayer/workers/sentTxWorker.ts
@@ -97,7 +97,7 @@ export async function createSentTxWorker<T extends EstimationType>(gasPrice: Gas
 
     if (shouldReprocess) {
       // TODO: handle this case later
-      logger.warn('Ambiguity detected: nonce increased but no respond that transaction was mined')
+      jobLogger.warn('Ambiguity detected: nonce increased but no respond that transaction was mined')
       // Error should be caught by `withLoop` to re-run job
       throw new Error(RECHECK_ERROR)
     }

--- a/zp-relayer/workers/sentTxWorker.ts
+++ b/zp-relayer/workers/sentTxWorker.ts
@@ -7,10 +7,16 @@ import config from '@/config'
 import { pool } from '@/pool'
 import { web3, web3Redundant } from '@/services/web3'
 import { logger } from '@/services/appLogger'
-import { GasPrice, EstimationType, chooseGasPriceOptions, addExtraGasPrice, getMaxRequiredGasPrice } from '@/services/gas-price'
-import { buildPrefixedMemo, waitForFunds, withErrorLog, withLoop, withMutex } from '@/utils/helpers'
+import {
+  GasPrice,
+  EstimationType,
+  chooseGasPriceOptions,
+  addExtraGasPrice,
+  getMaxRequiredGasPrice,
+} from '@/services/gas-price'
+import { buildPrefixedMemo, withErrorLog, withLoop, withMutex } from '@/utils/helpers'
 import { OUTPLUSONE, SENT_TX_QUEUE_NAME } from '@/utils/constants'
-import { isGasPriceError, isInsufficientBalanceError, isSameTransactionError } from '@/utils/web3Errors'
+import { isGasPriceError, isInsufficientBalanceError, isNonceError, isSameTransactionError } from '@/utils/web3Errors'
 import { SendAttempt, SentTxPayload, sentTxQueue, SentTxResult, SentTxState } from '@/queue/sentTxQueue'
 import { sendTransaction, signTransaction } from '@/tx/signAndSend'
 import { poolTxQueue } from '@/queue/poolTxQueue'
@@ -78,8 +84,8 @@ export async function createSentTxWorker<T extends EstimationType>(gasPrice: Gas
     return [null, true]
   }
 
-  const sentTxWorkerProcessor = async (job: Job<SentTxPayload>) => {
-    const jobLogger = workerLogger.child({ jobId: job.id, traceId: job.data.traceId })
+  const sentTxWorkerProcessor = async (job: Job<SentTxPayload>, resendNum: number = 1) => {
+    const jobLogger = workerLogger.child({ jobId: job.id, traceId: job.data.traceId, resendNum })
 
     jobLogger.info('Verifying job %s', job.data.poolJobId)
     const { truncatedMemo, commitIndex, outCommit, nullifier, root, prevAttempts, txConfig } = job.data
@@ -91,8 +97,9 @@ export async function createSentTxWorker<T extends EstimationType>(gasPrice: Gas
 
     if (shouldReprocess) {
       // TODO: handle this case later
+      logger.warn('Ambiguity detected: nonce increased but no respond that transaction was mined')
       // Error should be caught by `withLoop` to re-run job
-      throw new Error('Ambiguity detected: nonce increased but no respond that transaction was mined')
+      throw new Error(RECHECK_ERROR)
     }
 
     if (tx) {
@@ -175,6 +182,10 @@ export async function createSentTxWorker<T extends EstimationType>(gasPrice: Gas
       }
     } else {
       // Resend with updated gas price
+      if (resendNum > config.sentTxLogErrorThreshold) {
+        jobLogger.error('Too many unsuccessful re-sends')
+      }
+
       const fetchedGasPrice = await gasPrice.fetchOnce()
       const oldWithExtra = addExtraGasPrice(lastGasPrice, config.minGasPriceBumpFactor, null)
       const newWithExtra = addExtraGasPrice(fetchedGasPrice, config.gasPriceSurplus, null)
@@ -195,7 +206,7 @@ export async function createSentTxWorker<T extends EstimationType>(gasPrice: Gas
         jobLogger.info('Re-send tx', { txHash: newTxHash })
       } catch (e) {
         const err = e as Error
-        jobLogger.warn('Tx resend failed: %s', err.message, { txHash: newTxHash })
+        jobLogger.warn('Tx resend failed', { error: err.message, txHash: newTxHash })
         if (isGasPriceError(err) || isSameTransactionError(err)) {
           // Tx wasn't sent successfully, but still update last attempt's
           // gasPrice to be accounted in the next iteration
@@ -207,7 +218,11 @@ export async function createSentTxWorker<T extends EstimationType>(gasPrice: Gas
           job.data.prevAttempts.at(-1)![1] = lastGasPrice
 
           const minimumBalance = toBN(txConfig.gas!).mul(toBN(getMaxRequiredGasPrice(newGasPrice)))
-          logger.error('Insufficient balance, waiting for funds', { minimumBalance: minimumBalance.toString(10) })
+          jobLogger.error('Insufficient balance, waiting for funds', { minimumBalance: minimumBalance.toString(10) })
+        } else if (isNonceError(err)) {
+          jobLogger.warn('Nonce error', { error: err.message, txHash: newTxHash })
+          // Throw suppressed error to be treated as a warning
+          throw new Error(RECHECK_ERROR)
         }
         // Error should be caught by `withLoop` to re-run job
         throw e
@@ -235,7 +250,7 @@ export async function createSentTxWorker<T extends EstimationType>(gasPrice: Gas
     job =>
       withErrorLog(
         withLoop(
-          withMutex(mutex, () => sentTxWorkerProcessor(job)),
+          withMutex(mutex, (i: number) => sentTxWorkerProcessor(job, i)),
           config.sentTxDelay,
           [RECHECK_ERROR]
         )


### PR DESCRIPTION
Changes:
* Add iteration count to `sentTxWorker`.
* Reduce log level of `Ambiguity detected` errors to warn.
* Reduce log level of `nonce too low` errors to warn (for `sentTxWorker` only).
* Add `SENT_TX_ERROR_THRESHOLD` env. If re-send iteration count is more that this threshold, then corresponding error will be logged.
Closes #136 