### PR TITLE
Enhancement/request logs

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -13,6 +13,7 @@
 | TREE_UPDATE_PARAMS_PATH | Local path to tree update circuit parameters | string |
 | TRANSFER_PARAMS_PATH | Local path to transfer circuit parameters | string |
 | TX_VK_PATH | Local path to transaction circuit verification key | string |
+| RELAYER_REQUEST_LOG_PATH | Path to a file where all HTTP request logs will be saved. Default `./zp.log`. | string |
 | STATE_DIR_PATH | Path to persistent state files related to tree and transactions storage. Default: `./POOL_STATE` | string |
 | GAS_PRICE_FALLBACK | Default fallback gas price | integer |
 | GAS_PRICE_ESTIMATION_TYPE | Gas price estimation type | `web3` / `gas-price-oracle` / `eip1559-gas-estimation` / `polygon-gasstation-v2` |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -37,5 +37,7 @@
 | PERMIT_DEADLINE_THRESHOLD_RESEND | Minimum time threshold in seconds for permit signature deadline to be valid (for re-send attempts) | integer |
 | RELAYER_REQUIRE_TRACE_ID | If set to `true`, then requests to relayer (except `/info`, `/version`, `/params/hash/tree`, `/params/hash/tx`) without `zkbob-support-id` header will be rejected. | boolean |
 | RELAYER_REQUIRE_HTTPS | If set to `true`, then RPC URL(s) must be in HTTPS format. HTTP RPC URL(s) should be used in test environment only. | boolean |
+| RELAYER_LOG_IGNORE_ROUTES | List of space separated relayer endpoints for which request logging will be suppressed. E.g. `/fee /version` | string(s) |
+| RELAYER_LOG_HEADER_BLACKLIST | List of space separated HTTP headers which will be suppressed in request logs. E.g. `content-length content-type` | string(s) |
 | RELAYER_SCREENER_URL | Screener service URL | URL |
 | RELAYER_SCREENER_TOKEN | Authorization token for screener service | string |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ You can use a pre-built [image](https://github.com/zkBob/zeropool-relayer/pkgs/c
 cd zp-relayer && yarn test:unit
 ```
 
+**Worker tests**
+To run worker tests you need Docker and docker-compose installed locally.
+```bash
+cd zp-relayer && yarn test:worker
+```
 
 ## Workflow
 

--- a/zp-relayer/config.ts
+++ b/zp-relayer/config.ts
@@ -7,6 +7,9 @@ const relayerAddress = new Web3().eth.accounts.privateKeyToAccount(
   process.env.RELAYER_ADDRESS_PRIVATE_KEY as string
 ).address
 
+const defaultHeaderBlacklist =
+  'accept accept-language accept-encoding connection content-length content-type postman-token referer upgrade-insecure-requests'
+
 const config = {
   relayerRef: process.env.RELAYER_REF || null,
   relayerSHA: process.env.RELAYER_SHA || null,
@@ -51,6 +54,9 @@ const config = {
   requireTraceId: process.env.RELAYER_REQUIRE_TRACE_ID === 'true',
   requireHTTPS: process.env.RELAYER_REQUIRE_HTTPS === 'true',
   logIgnoreRoutes: (process.env.RELAYER_LOG_IGNORE_ROUTES || '').split(' ').filter(r => r.length > 0),
+  logHeaderBlacklist: (process.env.RELAYER_LOG_HEADER_BLACKLIST || defaultHeaderBlacklist)
+    .split(' ')
+    .filter(r => r.length > 0),
   screenerUrl: process.env.RELAYER_SCREENER_URL || null,
   screenerToken: process.env.RELAYER_SCREENER_TOKEN || null,
 }

--- a/zp-relayer/config.ts
+++ b/zp-relayer/config.ts
@@ -21,6 +21,7 @@ const config = {
   treeUpdateParamsPath: process.env.TREE_UPDATE_PARAMS_PATH || './params/tree_params.bin',
   transferParamsPath: process.env.TRANSFER_PARAMS_PATH || './params/transfer_params.bin',
   txVKPath: process.env.TX_VK_PATH || './params/transfer_verification_key.json',
+  requestLogPath: process.env.RELAYER_REQUEST_LOG_PATH || './zp.log',
   stateDirPath: process.env.STATE_DIR_PATH || './POOL_STATE',
   gasPriceFallback: process.env.GAS_PRICE_FALLBACK as string,
   gasPriceEstimationType: (process.env.GAS_PRICE_ESTIMATION_TYPE as EstimationType) || 'web3',

--- a/zp-relayer/config.ts
+++ b/zp-relayer/config.ts
@@ -47,6 +47,7 @@ const config = {
     .map(s => parseInt(s, 10)),
   requireTraceId: process.env.RELAYER_REQUIRE_TRACE_ID === 'true',
   requireHTTPS: process.env.RELAYER_REQUIRE_HTTPS === 'true',
+  logIgnoreRoutes: (process.env.RELAYER_LOG_IGNORE_ROUTES || '').split(' ').filter(r => r.length > 0),
 }
 
 export default config

--- a/zp-relayer/config.ts
+++ b/zp-relayer/config.ts
@@ -44,8 +44,9 @@ const config = {
   insufficientBalanceCheckTimeout: parseInt(process.env.INSUFFICIENT_BALANCE_CHECK_TIMEOUT || '60000'),
   rpcSyncCheckInterval: parseInt(process.env.RELAYER_RPC_SYNC_STATE_CHECK_INTERVAL || '0'),
   permitDeadlineThresholdInitial: parseInt(process.env.PERMIT_DEADLINE_THRESHOLD_INITIAL || '300'),
-  relayerJsonRpcErrorCodes: (process.env.RELAYER_JSONRPC_ERROR_CODES || '-32603,-32002,-32005')
-    .split(',')
+  relayerJsonRpcErrorCodes: (process.env.RELAYER_JSONRPC_ERROR_CODES || '-32603 -32002 -32005')
+    .split(' ')
+    .filter(s => s.length > 0)
     .map(s => parseInt(s, 10)),
   requireTraceId: process.env.RELAYER_REQUIRE_TRACE_ID === 'true',
   requireHTTPS: process.env.RELAYER_REQUIRE_HTTPS === 'true',

--- a/zp-relayer/index.ts
+++ b/zp-relayer/index.ts
@@ -8,7 +8,7 @@ import { init } from './init'
 
 const app = express()
 
-app.use(createPersistentLoggerMiddleware('zp.log'))
+app.use(createPersistentLoggerMiddleware(config.requestLogPath))
 app.use(createConsoleLoggerMiddleware())
 
 app.use(router)

--- a/zp-relayer/index.ts
+++ b/zp-relayer/index.ts
@@ -2,13 +2,14 @@ import './env'
 import express from 'express'
 import router from './router'
 import { logger } from './services/appLogger'
-import { createLoggerMiddleware } from './services/loggerMiddleware'
+import { createConsoleLoggerMiddleware, createPersistentLoggerMiddleware } from './services/loggerMiddleware'
 import config from './config'
 import { init } from './init'
 
 const app = express()
 
-app.use(createLoggerMiddleware('zp.log'))
+app.use(createPersistentLoggerMiddleware('zp.log'))
+app.use(createConsoleLoggerMiddleware())
 
 app.use(router)
 

--- a/zp-relayer/services/loggerMiddleware.ts
+++ b/zp-relayer/services/loggerMiddleware.ts
@@ -1,9 +1,22 @@
-import winston from 'winston'
+import { format, transports } from 'winston'
 import expressWinston from 'express-winston'
+import config from '@/config'
 
 export function createLoggerMiddleware(filename: string = 'zp.log') {
   return expressWinston.logger({
-    transports: [new winston.transports.File({ filename })],
-    format: winston.format.combine(winston.format.json()),
+    transports: [new transports.File({ filename, level: 'debug' }), new transports.Console()],
+    format: format.combine(format.colorize(), format.simple()),
+    ignoredRoutes: config.logIgnoreRoutes,
+    headerBlacklist: [
+      'accept',
+      'accept-language',
+      'accept-encoding',
+      'connection',
+      'content-length',
+      'content-type',
+      'postman-token',
+      'referer',
+      'upgrade-insecure-requests',
+    ],
   })
 }

--- a/zp-relayer/services/loggerMiddleware.ts
+++ b/zp-relayer/services/loggerMiddleware.ts
@@ -2,9 +2,16 @@ import { format, transports } from 'winston'
 import expressWinston from 'express-winston'
 import config from '@/config'
 
-export function createLoggerMiddleware(filename: string = 'zp.log') {
+export function createPersistentLoggerMiddleware(filename: string = 'zp.log') {
   return expressWinston.logger({
-    transports: [new transports.File({ filename, level: 'debug' }), new transports.Console()],
+    transports: [new transports.File({ filename })],
+    format: format.combine(format.json()),
+  })
+}
+
+export function createConsoleLoggerMiddleware() {
+  return expressWinston.logger({
+    transports: [new transports.Console()],
     format: format.combine(format.colorize(), format.simple()),
     ignoredRoutes: config.logIgnoreRoutes,
     headerBlacklist: [

--- a/zp-relayer/services/loggerMiddleware.ts
+++ b/zp-relayer/services/loggerMiddleware.ts
@@ -1,6 +1,7 @@
 import { format, transports } from 'winston'
 import expressWinston from 'express-winston'
 import config from '@/config'
+import { logger } from './appLogger'
 
 export function createPersistentLoggerMiddleware(filename: string = 'zp.log') {
   return expressWinston.logger({
@@ -11,8 +12,8 @@ export function createPersistentLoggerMiddleware(filename: string = 'zp.log') {
 
 export function createConsoleLoggerMiddleware() {
   return expressWinston.logger({
-    transports: [new transports.Console()],
-    format: format.combine(format.colorize(), format.simple()),
+    winstonInstance: logger,
+    level: 'debug',
     ignoredRoutes: config.logIgnoreRoutes,
     headerBlacklist: [
       'accept',
@@ -25,5 +26,6 @@ export function createConsoleLoggerMiddleware() {
       'referer',
       'upgrade-insecure-requests',
     ],
+    requestWhitelist: ['headers', 'httpVersion'],
   })
 }

--- a/zp-relayer/services/loggerMiddleware.ts
+++ b/zp-relayer/services/loggerMiddleware.ts
@@ -15,17 +15,7 @@ export function createConsoleLoggerMiddleware() {
     winstonInstance: logger,
     level: 'debug',
     ignoredRoutes: config.logIgnoreRoutes,
-    headerBlacklist: [
-      'accept',
-      'accept-language',
-      'accept-encoding',
-      'connection',
-      'content-length',
-      'content-type',
-      'postman-token',
-      'referer',
-      'upgrade-insecure-requests',
-    ],
+    headerBlacklist: config.logHeaderBlacklist,
     requestWhitelist: ['headers', 'httpVersion'],
   })
 }


### PR DESCRIPTION
Changes:
* Request data is logged to console, as well as to a file. You can specify ignored routes (for console logging), space separated, via `RELAYER_LOG_IGNORE_ROUTES` env, e.g. `/fee /params/hash/tx`. Also, I removed some common headers from requests to not flood the logs. Example request log:
```
info: HTTP GET /params/hash/tree {"meta":{"req":{"headers":{"host":"127.0.0.1:8000","user-agent":"PostmanRuntime/7.30.0"},"httpVersion":"1.1","method":"GET","originalUrl":"/params/hash/tree","query":{},"url":"/params/hash/tree"},"res":{"statusCode":200},"responseTime":1}}
```
Closes #67 

This PR should be considered as a draft, so any suggestions about logs format are welcome.