### PR TITLE
Fix failed contract calls

### DIFF
--- a/zp-relayer/router.ts
+++ b/zp-relayer/router.ts
@@ -52,14 +52,14 @@ router.get('/params/hash/tree', wrapErr(endpoints.getParamsHash('tree')))
 router.get('/params/hash/tx', wrapErr(endpoints.getParamsHash('transfer')))
 
 // Error handler middleware
-router.use((err: any, req: Request, res: Response, next: NextFunction) => {
-  if (err instanceof ValidationError) {
-    const validationErrors = err.validationErrors
-    logger.info('Request errors: %o', validationErrors, { path: req.path })
+router.use((error: any, req: Request, res: Response) => {
+  if (error instanceof ValidationError) {
+    const validationErrors = error.validationErrors
+    logger.warn('Validation errors', { errors: validationErrors, path: req.path })
     res.status(400).json(validationErrors)
-    next()
   } else {
-    next(err)
+    logger.error('Internal error', { error, path: req.path })
+    res.status(500).send('Internal server error')
   }
 })
 

--- a/zp-relayer/utils/web3Errors.ts
+++ b/zp-relayer/utils/web3Errors.ts
@@ -28,3 +28,8 @@ export function isInsufficientBalanceError(e: Error) {
   const message = e.message.toLowerCase()
   return message.includes('insufficient funds')
 }
+
+export function isContractCallError(e: Error) {
+  const message = e.message.toLowerCase()
+  return message.includes('did it run out of gas')
+}


### PR DESCRIPTION
Changes:
* Add contract call retry functionality in most critical places. But, there a few questions for discussion. How many times should we retry failed calls? Which interval between retries to choose? For now, 2 retries with 500ms interval is set.
Closes #144 
* Improve error handling. Now, in case of unrecoverable error there will be no pure stack traces in logs, instead it will be wrapped in a json logger message. Also, in such cases server will return code 500 with plain text `Internal server error`, instead of HTML template with the same message.