### PR TITLE
Cache fee options

### DIFF
--- a/zp-relayer/configs/relayerConfig.ts
+++ b/zp-relayer/configs/relayerConfig.ts
@@ -65,6 +65,7 @@ const config = {
   treeProverType: (process.env.RELAYER_TREE_PROVER_TYPE || ProverType.Local) as ProverType,
   directDepositProverType: (process.env.RELAYER_DD_PROVER_TYPE || ProverType.Local) as ProverType,
   feeManagerType: (process.env.RELAYER_FEE_MANAGER_TYPE || FeeManagerType.Dynamic) as FeeManagerType,
+  feeManagerUpdateInterval: parseInt(process.env.RELAYER_FEE_MANAGER_UPDATE_INTERVAL || '10000'),
   feeMarginFactor: toBN(process.env.RELAYER_FEE_MARGIN_FACTOR || '100'),
   feeScalingFactor: toBN(process.env.RELAYER_FEE_SCALING_FACTOR || '100'),
   priceFeedType: (process.env.RELAYER_PRICE_FEED_TYPE || PriceFeedType.Native) as PriceFeedType,

--- a/zp-relayer/endpoints.ts
+++ b/zp-relayer/endpoints.ts
@@ -210,7 +210,7 @@ function getFeeBuilder(feeManager: FeeManager) {
   return async (req: Request, res: Response) => {
     validateBatch([[checkTraceId, req.headers]])
 
-    const feeOptions = await feeManager.getFees({ gasLimit: config.relayerGasLimit })
+    const feeOptions = await feeManager.getFeeOptions({ gasLimit: config.relayerGasLimit })
     const fees = feeOptions.denominate(pool.denominator).getObject()
 
     res.json(fees)

--- a/zp-relayer/init.ts
+++ b/zp-relayer/init.ts
@@ -41,6 +41,8 @@ function buildFeeManager(
     priceFeed,
     scaleFactor: config.feeScalingFactor,
     marginFactor: config.feeMarginFactor,
+    updateInterval: config.feeManagerUpdateInterval,
+    defaultFeeOptionsParams: { gasLimit: config.relayerGasLimit },
   }
   if (type === FeeManagerType.Static) {
     if (config.relayerFee === null) throw new Error('Static relayer fee is not set')
@@ -105,7 +107,7 @@ export async function init() {
 
   const priceFeed = buildPriceFeed(config.priceFeedType, web3)
   const feeManager = buildFeeManager(config.feeManagerType, priceFeed, gasPriceService, web3)
-  await feeManager.init()
+  await feeManager.start()
 
   const workerPromises = [
     createPoolTxWorker({

--- a/zp-relayer/services/fee/DynamicFeeManager.ts
+++ b/zp-relayer/services/fee/DynamicFeeManager.ts
@@ -21,7 +21,7 @@ export class DynamicFeeManager extends FeeManager {
     return new FeeEstimate(toBN(fee))
   }
 
-  async _getFees({ gasLimit }: IGetFeesParams) {
+  async _fetchFeeOptions({ gasLimit }: IGetFeesParams) {
     const baseFee = await FeeManager.estimateExecutionFee(this.gasPrice, gasLimit)
     return new DefaultUserFeeOptions(baseFee)
   }

--- a/zp-relayer/services/fee/FeeManager.ts
+++ b/zp-relayer/services/fee/FeeManager.ts
@@ -112,9 +112,11 @@ export abstract class FeeManager {
     let feeOptions: IUserFeeOptions
     try {
       feeOptions = await this.fetchFeeOptions(params)
+      logger.debug('Fetched fee options', feeOptions.getObject())
     } catch (e) {
       logger.error('Failed to fetch fee options', e)
       if (!this.cachedFeeOptions) throw e
+      logger.debug('Fallback to cache fee options')
       feeOptions = this.cachedFeeOptions
     }
     return feeOptions

--- a/zp-relayer/services/fee/FeeManager.ts
+++ b/zp-relayer/services/fee/FeeManager.ts
@@ -109,7 +109,15 @@ export abstract class FeeManager {
 
   async getFeeOptions(params: IGetFeesParams, useCached = true): Promise<IUserFeeOptions> {
     if (useCached && this.cachedFeeOptions) return this.cachedFeeOptions
-    return this.fetchFeeOptions(params)
+    let feeOptions: IUserFeeOptions
+    try {
+      feeOptions = await this.fetchFeeOptions(params)
+    } catch (e) {
+      logger.error('Failed to fetch fee options', e)
+      if (!this.cachedFeeOptions) throw e
+      feeOptions = this.cachedFeeOptions
+    }
+    return feeOptions
   }
 
   // Should be used for tx fee validation

--- a/zp-relayer/services/fee/OptimismFeeManager.ts
+++ b/zp-relayer/services/fee/OptimismFeeManager.ts
@@ -43,7 +43,7 @@ class OptimismUserFeeOptions implements IUserFeeOptions {
 
   getObject() {
     return {
-      baseFee: this.baseFee.toString(10),
+      fee: this.baseFee.toString(10),
       oneByteFee: this.oneByteFee.toString(10),
     }
   }
@@ -84,7 +84,7 @@ export class OptimismFeeManager extends FeeManager {
   }
 
   async _estimateFee({ extraData }: IFeeEstimateParams, feeOptions: OptimismUserFeeOptions) {
-    const { baseFee, oneByteFee } = feeOptions.getObject()
+    const { fee: baseFee, oneByteFee } = feeOptions.getObject()
 
     const unscaledL1Fee = this.getL1Fee(MOCK_CALLDATA + extraData, toBN(oneByteFee))
 
@@ -92,9 +92,9 @@ export class OptimismFeeManager extends FeeManager {
     // We do it here to get a more accurate result
     const l1Fee = unscaledL1Fee.divn(NZERO_BYTE_GAS)
 
-    const fee = toBN(baseFee).add(l1Fee)
+    const feeEstimate = toBN(baseFee).add(l1Fee)
 
-    return new FeeEstimate(fee)
+    return new FeeEstimate(feeEstimate)
   }
 
   async _fetchFeeOptions({ gasLimit }: IGetFeesParams): Promise<OptimismUserFeeOptions> {

--- a/zp-relayer/services/fee/OptimismFeeManager.ts
+++ b/zp-relayer/services/fee/OptimismFeeManager.ts
@@ -100,7 +100,6 @@ export class OptimismFeeManager extends FeeManager {
   async _fetchFeeOptions({ gasLimit }: IGetFeesParams): Promise<OptimismUserFeeOptions> {
     const baseFee = await FeeManager.estimateExecutionFee(this.gasPrice, gasLimit)
 
-    // TODO: cache
     const l1BaseFee = await contractCallRetry(this.oracle, 'l1BaseFee').then(toBN)
     // Use an upper bound for the oneByteFee
     const oneByteFee = l1BaseFee.muln(NZERO_BYTE_GAS)

--- a/zp-relayer/services/fee/OptimismFeeManager.ts
+++ b/zp-relayer/services/fee/OptimismFeeManager.ts
@@ -97,7 +97,7 @@ export class OptimismFeeManager extends FeeManager {
     return new FeeEstimate(fee)
   }
 
-  async _getFees({ gasLimit }: IGetFeesParams): Promise<OptimismUserFeeOptions> {
+  async _fetchFeeOptions({ gasLimit }: IGetFeesParams): Promise<OptimismUserFeeOptions> {
     const baseFee = await FeeManager.estimateExecutionFee(this.gasPrice, gasLimit)
 
     // TODO: cache

--- a/zp-relayer/services/fee/StaticFeeManager.ts
+++ b/zp-relayer/services/fee/StaticFeeManager.ts
@@ -12,7 +12,7 @@ export class StaticFeeManager extends FeeManager {
     return new FeeEstimate(this.staticFee)
   }
 
-  async _getFees() {
+  async _fetchFeeOptions() {
     return new DefaultUserFeeOptions(this.staticFee)
   }
 }

--- a/zp-relayer/test/worker-tests/poolWorker.test.ts
+++ b/zp-relayer/test/worker-tests/poolWorker.test.ts
@@ -39,7 +39,7 @@ import flowZeroAddressWithdraw from '../flows/flow_zero-address_withdraw_2.json'
 import { Params } from 'libzkbob-rs-node'
 import { directDepositQueue } from '../../queue/directDepositQueue'
 import { createDirectDepositWorker } from '../../workers/directDepositWorker'
-import { FeeManager, DefaultFeeManager } from '../../services/fee'
+import { DynamicFeeManager, FeeManager } from '../../services/fee'
 
 chai.use(chaiAsPromised)
 const expect = chai.expect
@@ -106,9 +106,11 @@ describe('poolWorker', () => {
       priceFeed: mockPriceFeed,
       scaleFactor: toBN(1),
       marginFactor: toBN(1),
+      updateInterval: config.feeManagerUpdateInterval,
+      defaultFeeOptionsParams: { gasLimit: config.relayerGasLimit },
     }
-    feeManager = new DefaultFeeManager(managerConfig)
-    await feeManager.init()
+    feeManager = new DynamicFeeManager(managerConfig, gasPriceService)
+    await feeManager.start()
 
     txManager = new TxManager(web3, config.relayerPrivateKey, gasPriceService)
     await txManager.init()


### PR DESCRIPTION
Cache fee options to prevent possible relayer's API abuse and to reduce the number of possible client side errors when `/fee` endpoint internally fails (now, it uses cache). Also, during fee validation stage, relayer will fallback to cached value if fetch function fails.