### PR TITLE
Support new message prefix

### DIFF
--- a/zp-relayer/utils/constants.ts
+++ b/zp-relayer/utils/constants.ts
@@ -30,7 +30,7 @@ const constants = {
     randomize: true,
   },
   MESSAGE_PREFIX_COMMON_V1: '0000',
-  MESSAGE_PREFIX_COMMON_V2: '0100',
+  MESSAGE_PREFIX_COMMON_V2: '0002',
   HEADER_TRACE_ID: 'zkbob-support-id' as const,
   HEADER_LIBJS: 'zkbob-libjs-version' as const,
   LIBJS_MIN_VERSION: '2.0.0',

--- a/zp-relayer/utils/constants.ts
+++ b/zp-relayer/utils/constants.ts
@@ -30,6 +30,7 @@ const constants = {
     randomize: true,
   },
   MESSAGE_PREFIX_COMMON_V1: '0000',
+  MESSAGE_PREFIX_COMMON_V2: '0100',
   HEADER_TRACE_ID: 'zkbob-support-id' as const,
   HEADER_LIBJS: 'zkbob-libjs-version' as const,
   LIBJS_MIN_VERSION: '2.0.0',

--- a/zp-relayer/validation/tx/validateTx.ts
+++ b/zp-relayer/validation/tx/validateTx.ts
@@ -9,7 +9,7 @@ import type { Limits, Pool } from '@/pool'
 import type { NullifierSet } from '@/state/nullifierSet'
 import { web3 } from '@/services/web3'
 import { applyDenominator, contractCallRetry, numToHex, truncateMemoTxPrefix, unpackSignature } from '@/utils/helpers'
-import { ZERO_ADDRESS, MESSAGE_PREFIX_COMMON_V1, MOCK_CALLDATA } from '@/utils/constants'
+import { ZERO_ADDRESS, MESSAGE_PREFIX_COMMON_V1, MESSAGE_PREFIX_COMMON_V2, MOCK_CALLDATA } from '@/utils/constants'
 import { getTxProofField, parseDelta } from '@/utils/proofInputs'
 import type { TxPayload } from '@/queue/poolTxQueue'
 import type { PoolState } from '@/state/PoolState'
@@ -189,7 +189,7 @@ function checkPoolId(deltaPoolId: BN, contractPoolId: BN) {
 
 function checkMemoPrefix(memo: string, txType: TxType) {
   const numItemsSuffix = truncateMemoTxPrefix(memo, txType).substring(4, 8)
-  if (numItemsSuffix === MESSAGE_PREFIX_COMMON_V1) {
+  if (numItemsSuffix === MESSAGE_PREFIX_COMMON_V1 || numItemsSuffix === MESSAGE_PREFIX_COMMON_V2) {
     return null
   }
   return new TxValidationError(`Memo prefix is incorrect: ${numItemsSuffix}`)


### PR DESCRIPTION
This pull request enables the provision of a new message prefix: `0x0100`. This is essential to support the new memo encryption scheme described in https://github.com/zkBob/libzeropool-zkbob/issues/14.