### PR TITLE
Fix commitment processing condition

### DIFF
--- a/zp-relayer/commitment-watcher/init.ts
+++ b/zp-relayer/commitment-watcher/init.ts
@@ -78,7 +78,7 @@ async function processCommitment(pendingCommitment: PendingCommitment) {
 
   const currentTimestamp = new BN(Math.floor(Date.now() / 1000))
 
-  if (privilegedProver !== config.txManager.TX_ADDRESS && toBN(timestamp).lt(currentTimestamp)) {
+  if (privilegedProver !== config.txManager.TX_ADDRESS && currentTimestamp.lt(toBN(gracePeriodEnd))) {
     logger.info('Not allowed to submit the proof yet, waiting...')
     return
   }


### PR DESCRIPTION
It seems that this condition was incorrect. I've checked the new one and it works properly.
<img width="1048" alt="image" src="https://github.com/zkBob/zeropool-relayer/assets/17165678/3b76f2af-efbe-446b-ae16-ed12e1b834f3">
