### PR TITLE
Fix/prover sync

### DIFF
--- a/zp-relayer/pool/BasePool.ts
+++ b/zp-relayer/pool/BasePool.ts
@@ -188,9 +188,9 @@ export abstract class BasePool<N extends Network = Network> {
 
   async syncStateFromIndexer(indexerUrl: string) {
     let txs = []
-    let commitIndex = this.optimisticState.getNextIndex() / OUTPLUSONE
+    let commitIndex = this.state.getNextIndex() / OUTPLUSONE
     do {
-      txs = await this.fetchTransactionsFromIndexer(indexerUrl, this.optimisticState.getNextIndex(), 200)
+      txs = await this.fetchTransactionsFromIndexer(indexerUrl, this.state.getNextIndex(), 200)
       for (const tx of txs) {
         const outCommit = hexToNumberString('0x' + tx.commitment)
         this.optimisticState.addCommitment(commitIndex, Helpers.strToNum(outCommit))

--- a/zp-relayer/pool/BasePool.ts
+++ b/zp-relayer/pool/BasePool.ts
@@ -178,6 +178,9 @@ export abstract class BasePool<N extends Network = Network> {
       newLocalRoot,
       newLocalIndex,
     })
+    if (newLocalIndex < contractIndex) {
+      throw new Error('Indexer is not syncronized with the contract yet')
+    }
     if (newLocalRoot !== contractRoot) {
       throw new Error('State is corrupted, roots mismatch')
     }

--- a/zp-relayer/pool/BasePool.ts
+++ b/zp-relayer/pool/BasePool.ts
@@ -188,9 +188,10 @@ export abstract class BasePool<N extends Network = Network> {
 
   async syncStateFromIndexer(indexerUrl: string) {
     let txs = []
-    let commitIndex = this.state.getNextIndex() / OUTPLUSONE
+    let offset = this.state.getNextIndex()
+    let commitIndex = offset / OUTPLUSONE
     do {
-      txs = await this.fetchTransactionsFromIndexer(indexerUrl, this.state.getNextIndex(), 200)
+      txs = await this.fetchTransactionsFromIndexer(indexerUrl, offset, 200)
       for (const tx of txs) {
         const outCommit = hexToNumberString('0x' + tx.commitment)
         this.optimisticState.addCommitment(commitIndex, Helpers.strToNum(outCommit))
@@ -199,6 +200,7 @@ export abstract class BasePool<N extends Network = Network> {
         }
         commitIndex++
       }
+      offset = this.optimisticState.getNextIndex()
     } while (txs.length !== 0)
   }
 

--- a/zp-relayer/pool/BasePool.ts
+++ b/zp-relayer/pool/BasePool.ts
@@ -179,7 +179,7 @@ export abstract class BasePool<N extends Network = Network> {
       newLocalIndex,
     })
     if (newLocalIndex < contractIndex) {
-      throw new Error('Indexer is not syncronized with the contract yet')
+      throw new Error('Indexer is not synchronized with the contract yet')
     }
     if (newLocalRoot !== contractRoot) {
       throw new Error('State is corrupted, roots mismatch')

--- a/zp-relayer/pool/FinalizerPool.ts
+++ b/zp-relayer/pool/FinalizerPool.ts
@@ -143,16 +143,10 @@ export class FinalizerPool extends BasePool {
       logger.error('Pool job not found', { jobId });
       return;
     }
-    
+
     const poolJob = await poolTxQueue.getJob(jobId);
     if (poolJob?.data.type === WorkerTxType.Finalize) {
       this.state.updateState(commitIndex, outCommit, prefixedMemo)
-
-      // Add nullifier to confirmed state and remove from optimistic one
-      if (nullifier) {
-        logger.info('Adding nullifier %s to PS', nullifier)
-        await this.state.nullifiers.add([nullifier])
-      }
 
       const rootConfirmed = this.state.getMerkleRoot()
       logger.info('Assert roots are equal')

--- a/zp-relayer/pool/FinalizerPool.ts
+++ b/zp-relayer/pool/FinalizerPool.ts
@@ -1,6 +1,6 @@
 import { logger } from '@/lib/appLogger'
 import { Circuit, IProver } from '@/prover'
-import { DirectDeposit, PoolTx, WorkerTxType } from '@/queue/poolTxQueue'
+import { DirectDeposit, PoolTx, poolTxQueue, WorkerTxType } from '@/queue/poolTxQueue'
 import { buildPrefixedMemo, flattenProof } from '@/utils/helpers'
 import { DelegatedDepositsData } from 'libzkbob-rs-node'
 import AbiCoder from 'web3-eth-abi'
@@ -133,24 +133,34 @@ export class FinalizerPool extends BasePool {
   async onConfirmed(
     { outCommit, memo, commitIndex, nullifier, root }: ProcessResult<this>,
     txHash: string,
-    callback?: (() => Promise<void>) | undefined
+    callback?: (() => Promise<void>) | undefined, 
+    jobId?: string
   ): Promise<void> {
     const prefixedMemo = buildPrefixedMemo(outCommit, txHash, memo)
-    this.state.updateState(commitIndex, outCommit, prefixedMemo)
     this.optimisticState.updateState(commitIndex, outCommit, prefixedMemo)
-
-    // Add nullifier to confirmed state and remove from optimistic one
-    if (nullifier) {
-      logger.info('Adding nullifier %s to PS', nullifier)
-      await this.state.nullifiers.add([nullifier])
+    
+    if (!jobId) {
+      logger.error('Pool job not found', { jobId });
+      return;
     }
+    
+    const poolJob = await poolTxQueue.getJob(jobId);
+    if (poolJob?.data.type === WorkerTxType.Finalize) {
+      this.state.updateState(commitIndex, outCommit, prefixedMemo)
 
-    const rootConfirmed = this.state.getMerkleRoot()
-    logger.info('Assert roots are equal')
-    if (rootConfirmed !== root) {
-      // TODO: Should be impossible but in such case
-      // we should recover from some checkpoint
-      logger.error('Roots are not equal: %s should be %s', rootConfirmed, root)
+      // Add nullifier to confirmed state and remove from optimistic one
+      if (nullifier) {
+        logger.info('Adding nullifier %s to PS', nullifier)
+        await this.state.nullifiers.add([nullifier])
+      }
+
+      const rootConfirmed = this.state.getMerkleRoot()
+      logger.info('Assert roots are equal')
+      if (rootConfirmed !== root) {
+        // TODO: Should be impossible but in such case
+        // we should recover from some checkpoint
+        logger.error('Roots are not equal: %s should be %s', rootConfirmed, root)
+      }
     }
 
     if (callback) {

--- a/zp-relayer/services/commitment-watcher/init.ts
+++ b/zp-relayer/services/commitment-watcher/init.ts
@@ -27,7 +27,8 @@ async function processCommitment(pendingCommitment: PendingCommitment) {
     return
   }
 
-  if (await poolTxQueue.getJob(commitment)) {
+  const existingJob = await poolTxQueue.getJob(commitment);
+  if (existingJob && existingJob.data.transaction.state !== JobState.FAILED) {
     logger.info('Job already created, waiting...', { commitment })
     return
   }

--- a/zp-relayer/services/commitment-watcher/init.ts
+++ b/zp-relayer/services/commitment-watcher/init.ts
@@ -28,9 +28,14 @@ async function processCommitment(pendingCommitment: PendingCommitment) {
   }
 
   const existingJob = await poolTxQueue.getJob(commitment);
-  if (existingJob && existingJob.data.transaction.state !== JobState.FAILED) {
-    logger.info('Job already created, waiting...', { commitment })
-    return
+  if (existingJob) {
+    if (existingJob.data.transaction.state === JobState.FAILED) {
+      logger.info('Job failed, repeating...', { commitment })
+      await poolTxQueue.remove(commitment);
+    } else {
+      logger.info('Job already created, waiting...', { commitment })
+      return
+    }
   }
 
   const job = await poolTxQueue.add(

--- a/zp-relayer/workers/poolTxWorker.ts
+++ b/zp-relayer/workers/poolTxWorker.ts
@@ -39,6 +39,7 @@ export async function createPoolTxWorker({ redis, mutex, pool, txManager }: IPoo
     const jobLogger = workerLogger.child({ jobId: job.id, traceId })
     jobLogger.info('Processing...')
 
+    let processResult;
     try {
       await pool.validateTx(
         job.data,
@@ -47,6 +48,7 @@ export async function createPoolTxWorker({ redis, mutex, pool, txManager }: IPoo
         },
         traceId
       )
+      processResult = await pool.buildTx(job.data)
     } catch(e) {
       job.data.transaction.state = JobState.FAILED;
       job.failedReason = (e as Error).message;
@@ -54,7 +56,6 @@ export async function createPoolTxWorker({ redis, mutex, pool, txManager }: IPoo
       throw e;
     }
 
-    const processResult = await pool.buildTx(job.data)
     const { data, func } = processResult
 
     const gas = 2000000;


### PR DESCRIPTION
This PR fixes two issues:
1. If the prover tries to synchronize the state before the indexer has synchronized with the contract, the attempt to build the `proveTreeUpdate` transaction fails, and the prover gets stuck.
2. A successfully mined `appendDirectDeposits` transaction updates the state, breaking the synchronization process and causing the prover to get stuck.