### PR TITLE
Fix/pending txs

### DIFF
--- a/zp-relayer/lib/network/NetworkBackend.ts
+++ b/zp-relayer/lib/network/NetworkBackend.ts
@@ -11,6 +11,7 @@ export function isEthereum(n: NetworkBackend<Network>): n is NetworkBackend<Netw
 export interface Event {
   txHash: string
   values: Record<string, any>
+  blockNumber: number
 }
 
 export interface GetEventsConfig<N extends Network> {

--- a/zp-relayer/lib/network/evm/EvmBackend.ts
+++ b/zp-relayer/lib/network/evm/EvmBackend.ts
@@ -62,6 +62,7 @@ export class EvmBackend implements INetworkBackend<Network.Ethereum> {
             events: events.map(e => ({
               txHash: e.transactionHash,
               values: e.returnValues,
+              blockNumber: e.blockNumber,
             })),
             fromBlock,
             toBlock,

--- a/zp-relayer/lib/network/tron/TronBackend.ts
+++ b/zp-relayer/lib/network/tron/TronBackend.ts
@@ -49,6 +49,7 @@ export class TronBackend implements INetworkBackend<Network.Tron> {
       yield events.map((e: any) => ({
         txHash: e.transaction,
         values: e.result,
+        blockNumber: e.block,
       }))
 
       fingerprint = events[events.length - 1].fingerprint || null

--- a/zp-relayer/pool/DefaultPool.ts
+++ b/zp-relayer/pool/DefaultPool.ts
@@ -54,6 +54,8 @@ export class DefaultPool extends BasePool {
   treeProver!: IProver<Circuit.Tree>
   public permitRecover: PermitRecover | null = null
 
+  protected poolName(): string { return 'default-pool'; }
+
   async init(startBlock: number | null = null, treeProver: IProver<Circuit.Tree>) {
     if (this.isInitialized) return
 

--- a/zp-relayer/pool/FinalizerPool.ts
+++ b/zp-relayer/pool/FinalizerPool.ts
@@ -21,6 +21,8 @@ export class FinalizerPool extends BasePool {
   directDepositProver!: IProver<Circuit.DirectDeposit>
   indexerUrl!: string
 
+  protected poolName(): string { return 'finalizer-pool'; }
+
   async init(
     treeProver: IProver<Circuit.Tree>,
     directDepositProver: IProver<Circuit.DirectDeposit>,

--- a/zp-relayer/pool/IndexerPool.ts
+++ b/zp-relayer/pool/IndexerPool.ts
@@ -6,6 +6,8 @@ import { type PermitRecover } from '@/utils/permit/types'
 export class IndexerPool extends BasePool {
   public permitRecover: PermitRecover | null = null
 
+  protected poolName(): string { return 'indexer-pool'; }
+
   async init(startBlock: number | null = null, lastBlock: number | null = null) {
     if (this.isInitialized) return
 

--- a/zp-relayer/pool/RelayPool.ts
+++ b/zp-relayer/pool/RelayPool.ts
@@ -365,7 +365,7 @@ export class RelayPool extends BasePool<Network> {
         const indexerCommitments = (await this.getIndexerTxs(fromIndex, limit)).map(tx => tx.slice(65, 129));
 
         // find cached commitments in the indexer's response
-        for (const [commit, memo] of localEntries) {
+        for (const [commit, {memo, index}] of localEntries) {
           if (indexerCommitments.includes(commit)) {
             logger.info('Deleting cached entry', { commit })
             await this.txStore.remove(commit)

--- a/zp-relayer/pool/RelayPool.ts
+++ b/zp-relayer/pool/RelayPool.ts
@@ -54,6 +54,8 @@ export class RelayPool extends BasePool<Network> {
   private observePromise: Promise<void> | undefined;
   txStore!: TxStore
 
+  protected poolName(): string { return 'relay-pool'; }
+
   async init(permitConfig: PermitConfig, proxyAddress: string, indexerUrl: string) {
     if (this.isInitialized) return
 

--- a/zp-relayer/pool/RelayPool.ts
+++ b/zp-relayer/pool/RelayPool.ts
@@ -262,7 +262,7 @@ export class RelayPool extends BasePool<Network> {
     }
 
     // cache transaction locally
-    await this.cacheTxLocally(outCommit, txHash, memo);
+    await this.cacheTxLocally(outCommit, txHash, memo, commitIndex);
     // start monitoring local cache against the indexer to cleanup already indexed txs
     this.startLocalCacheObserver(commitIndex);
   }
@@ -278,7 +278,7 @@ export class RelayPool extends BasePool<Network> {
         poolJob.data.transaction.txHash = txHash;
         await poolJob.update(poolJob.data);
 
-        await this.cacheTxLocally(res.outCommit, txHash, res.memo);
+        await this.cacheTxLocally(res.outCommit, txHash, res.memo, res.commitIndex);
       }
     }
   }
@@ -296,7 +296,7 @@ export class RelayPool extends BasePool<Network> {
     }
   }
 
-  protected async cacheTxLocally(commit: string, txHash: string, memo: string) {
+  protected async cacheTxLocally(commit: string, txHash: string, memo: string, index: number) {
     // store or updating local tx store
     // (we should keep sent transaction until the indexer grab them)
     const prefixedMemo = buildPrefixedMemo(
@@ -304,7 +304,7 @@ export class RelayPool extends BasePool<Network> {
       txHash,
       memo
     );
-    await this.txStore.add(commit, prefixedMemo);
+    await this.txStore.add(commit, prefixedMemo, index);
     logger.info(`Tx with commit ${commit} has been CACHED locally`);
   }
 

--- a/zp-relayer/services/indexer/init.ts
+++ b/zp-relayer/services/indexer/init.ts
@@ -26,10 +26,10 @@ export async function init() {
       for (let event of batch) {
         if (event.values.message) {
           // Message event
-          await pool.addTxToState(event.txHash, event.values.index, event.values.message, 'optimistic')
+          await pool.addTxToState(event.txHash, event.values.index, event.values.message, 'optimistic', event.blockNumber)
         } else if (event.values.commitment) {
           // RootUpdated event
-          pool.propagateOptimisticState(event.values.index)
+          pool.propagateOptimisticState(event.values.index, event.blockNumber)
         }
       }
     },

--- a/zp-relayer/services/indexer/router.ts
+++ b/zp-relayer/services/indexer/router.ts
@@ -83,7 +83,7 @@ function getRoot(req: Request, res: Response, { pool }: PoolInjection) {
   validateBatch([[checkGetRoot, req.query]])
 
   const index = req.query.index as unknown as number
-  const root = pool.state.getMerkleRootAt(index)
+  const root = pool.state.getMerkleRootAt(index) ?? pool.optimisticState.getMerkleRootAt(index)
 
   res.json({ root })
 }

--- a/zp-relayer/services/relayer/endpoints.ts
+++ b/zp-relayer/services/relayer/endpoints.ts
@@ -102,7 +102,7 @@ async function getTransactionsV2(req: Request, res: Response, { pool }: PoolInje
 
   const indexerCommitments = indexerTxs.map(tx => tx.slice(65, 129));
   const optimisticTxs: string[] = []
-  for (const [commit, memo] of localEntries) {
+  for (const [commit, {memo, index}] of localEntries) {
     if (indexerCommitments.includes(commit)) {
       // !!! we shouldn't modify local cache from here. Just filter entries to return correct response
       //logger.info('Deleting index from optimistic state', { index })
@@ -187,7 +187,7 @@ async function relayerInfo(req: Request, res: Response, { pool }: PoolInjection)
   const pendingCnt = await txStore.getAll()
     .then(keys => {
       return Object.entries(keys)
-        .map(([i]) => parseInt(i) as number)
+        .map(([commit, {memo, index}]) => index)
         .filter(i => indexerMaxIdx <= i)
     })
     .then(a => a.length);

--- a/zp-relayer/services/relayer/endpoints.ts
+++ b/zp-relayer/services/relayer/endpoints.ts
@@ -20,6 +20,7 @@ import {
   validateCountryIP,
   ValidationFunction,
 } from '../../validation/api/validation'
+import BigNumber from 'bignumber.js'
 
 interface PoolInjection {
   pool: BasePool
@@ -98,16 +99,17 @@ async function getTransactionsV2(req: Request, res: Response, { pool }: PoolInje
   const indexerTxs: string[] = await response.json()
   
   const lastRequestedIndex = offset + limit * OUTPLUSONE;
+  const lastReceivedIndex = offset + indexerTxs.length * OUTPLUSONE;
   const txStore = (pool as RelayPool).txStore;
   const localEntries = await txStore.getAll().then(entries =>
     Object.entries(entries)
     .filter(([commit, {memo, index}]) => offset <= index && index < lastRequestedIndex)
   );
 
-  const indexerCommitments = indexerTxs.map(tx => tx.slice(65, 129));
+  const indexerCommitments = indexerTxs.map(tx => BigNumber(tx.slice(65, 129), 16).toString(10));
   const optimisticTxs: string[] = []
   for (const [commit, {memo, index}] of localEntries) {
-    if (indexerCommitments.includes(commit)) {
+    if (indexerCommitments.includes(commit) || index < lastReceivedIndex) {
       // !!! we shouldn't modify local cache from here. Just filter entries to return correct response
       //logger.info('Deleting index from optimistic state', { index })
       //await txStore.remove(commit)
@@ -192,7 +194,7 @@ async function relayerInfo(req: Request, res: Response, { pool }: PoolInjection)
     .then(keys => {
       return Object.entries(keys)
         .map(([commit, {memo, index}]) => index)
-        .filter(i => indexerMaxIdx <= i)
+        .filter(i => i >= indexerMaxIdx)
     })
     .then(a => a.length);
 

--- a/zp-relayer/services/relayer/endpoints.ts
+++ b/zp-relayer/services/relayer/endpoints.ts
@@ -93,7 +93,7 @@ async function getTransactionsV2(req: Request, res: Response, { pool }: PoolInje
 
   const response = await fetch(url)
   if (!response.ok) {
-    throw new Error(`Failed to fetch transactions from indexer. Status: ${res.status}`)
+    throw new Error(`Failed to fetch transactions from indexer. Status: ${response.status}`)
   }
   const indexerTxs: string[] = await response.json()
   
@@ -111,8 +111,9 @@ async function getTransactionsV2(req: Request, res: Response, { pool }: PoolInje
   for (const [index, memo] of indices) {
     const commitLocal = memo.slice(0, 64)
     if (indexerCommitments.includes(commitLocal)) {
-      logger.info('Deleting index from optimistic state', { index })
-      await txStore.remove(index.toString())
+      // !!! we shouldn't modify local cache from here. Just filter entries to return correct response
+      //logger.info('Deleting index from optimistic state', { index })
+      //await txStore.remove(index.toString())
     } else {
       optimisticTxs.push(txToV2Format('0', memo))
     }

--- a/zp-relayer/services/relayer/endpoints.ts
+++ b/zp-relayer/services/relayer/endpoints.ts
@@ -97,8 +97,12 @@ async function getTransactionsV2(req: Request, res: Response, { pool }: PoolInje
   }
   const indexerTxs: string[] = await response.json()
   
-  const txStore = (pool as RelayPool).txStore
-  const localEntries = Object.entries(await txStore.getAll());
+  const lastRequestedIndex = offset + limit * OUTPLUSONE;
+  const txStore = (pool as RelayPool).txStore;
+  const localEntries = await txStore.getAll().then(entries =>
+    Object.entries(entries)
+    .filter(([commit, {memo, index}]) => offset <= index && index < lastRequestedIndex)
+  );
 
   const indexerCommitments = indexerTxs.map(tx => tx.slice(65, 129));
   const optimisticTxs: string[] = []

--- a/zp-relayer/state/PoolState.ts
+++ b/zp-relayer/state/PoolState.ts
@@ -144,6 +144,16 @@ export class PoolState {
     }
   }
 
+  wipe() {
+    const stateNextIndex = this.tree.getNextIndex();
+    this.tree.wipe();
+    for (let i = 0; i < stateNextIndex; i += OUTPLUSONE) {
+      this.txs.delete(i)
+    }
+    this.jobIdsMapping.clear();
+    this.nullifiers.clear();
+  }
+
   async getTransactions(limit: number, offset: number) {
     // Round offset to OUTPLUSONE
     offset = Math.floor(offset / OUTPLUSONE) * OUTPLUSONE

--- a/zp-relayer/state/TxStore.ts
+++ b/zp-relayer/state/TxStore.ts
@@ -1,23 +1,39 @@
+import { hexToNumber, numberToHexPadded } from '@/utils/helpers';
 import type { Redis } from 'ioredis'
+
+const INDEX_BYTES = 6;
 
 export class TxStore {
   constructor(public name: string, private redis: Redis) {}
 
-  async add(commitment: string, memo: string) {
-    await this.redis.hset(this.name, { [commitment]: memo })
+  async add(commitment: string, memo: string, index: number) {
+    await this.redis.hset(this.name, { [commitment]: `${numberToHexPadded(index, INDEX_BYTES)}${memo}` })
   }
 
   async remove(commitment: string) {
     await this.redis.hdel(this.name, commitment)
   }
 
-  async get(commitment: string) {
-    const memo = await this.redis.hget(this.name, commitment)
-    return memo
+  async get(commitment: string): Promise<{memo: string, index: number} | null> {
+    const data = await this.redis.hget(this.name, commitment);
+
+    return data ? { 
+      memo: data.slice(INDEX_BYTES * 2),
+      index: hexToNumber(data.slice(0, INDEX_BYTES * 2)),
+    } : null;
   }
 
   async getAll() {
-    return await this.redis.hgetall(this.name)
+    return await this.redis.hgetall(this.name).then(keys => {
+      return Object.entries(keys)
+        .map(([commit, data]) => 
+          [commit,
+          { 
+            memo: data.slice(INDEX_BYTES * 2),
+            index: hexToNumber(data.slice(0, INDEX_BYTES * 2)),
+          }] as [string, {memo: string, index: number}]
+        )
+      }
   }
 
   async removeAll() {

--- a/zp-relayer/state/TxStore.ts
+++ b/zp-relayer/state/TxStore.ts
@@ -23,9 +23,9 @@ export class TxStore {
     } : null;
   }
 
-  async getAll() {
-    return await this.redis.hgetall(this.name).then(keys => {
-      return Object.entries(keys)
+  async getAll(): Promise<Record<string, {memo: string, index: number}>> {
+    return this.redis.hgetall(this.name).then(keys => Object.fromEntries(
+      Object.entries(keys)
         .map(([commit, data]) => 
           [commit,
           { 
@@ -33,7 +33,7 @@ export class TxStore {
             index: hexToNumber(data.slice(0, INDEX_BYTES * 2)),
           }] as [string, {memo: string, index: number}]
         )
-      }
+      ));
   }
 
   async removeAll() {

--- a/zp-relayer/state/TxStore.ts
+++ b/zp-relayer/state/TxStore.ts
@@ -3,16 +3,16 @@ import type { Redis } from 'ioredis'
 export class TxStore {
   constructor(public name: string, private redis: Redis) {}
 
-  async add(index: number, memo: string) {
-    await this.redis.hset(this.name, { [index]: memo })
+  async add(commitment: string, memo: string) {
+    await this.redis.hset(this.name, { [commitment]: memo })
   }
 
-  async remove(index: string) {
-    await this.redis.hdel(this.name, index)
+  async remove(commitment: string) {
+    await this.redis.hdel(this.name, commitment)
   }
 
-  async get(index: string) {
-    const memo = await this.redis.hget(this.name, index)
+  async get(commitment: string) {
+    const memo = await this.redis.hget(this.name, commitment)
     return memo
   }
 

--- a/zp-relayer/utils/helpers.ts
+++ b/zp-relayer/utils/helpers.ts
@@ -8,7 +8,7 @@ import type { SnarkProof } from 'libzkbob-rs-node'
 import promiseRetry from 'promise-retry'
 import type Web3 from 'web3'
 import type { Contract } from 'web3-eth-contract'
-import { padLeft, toBN } from 'web3-utils'
+import { padLeft, toBN, numberToHex } from 'web3-utils'
 import { TxType } from 'zp-memo-parser'
 import { isContractCallError } from './web3Errors'
 
@@ -315,4 +315,12 @@ export async function fetchJson(serverUrl: string, path: string, query: [string,
   }
 
   return await res.json()
+}
+
+export function numberToHexPadded(num: number, numBytes: number): string {
+  return padLeft(numberToHex(num).slice(2), numBytes * 2);
+}
+
+export function hexToNumber(hex: string): number {
+  return parseInt(hex, 16);
 }

--- a/zp-relayer/utils/web3.ts
+++ b/zp-relayer/utils/web3.ts
@@ -64,7 +64,7 @@ export async function getChainId(web3: Web3) {
 
 export async function getBlockNumber(network: NetworkBackend<Network>) {
   try {
-    logger.debug('Getting block number')
+    //logger.debug('Getting block number')
     const blockNumber = await network.getBlockNumber()
     logger.debug('Block number obtained', { blockNumber })
     return blockNumber


### PR DESCRIPTION
The PR intended to fix a set of issues:
1. Sync indexer's state starting from the last index (in case of Merkle tree was grown during proxy unavailability)
2. Pending tx local cache was redesigned to fix a different issues of returning state (storing by commitment instead of index)
3. Returning pending txs right after transaction sending (to avoid client inconsistence)
