### PR TITLE
Fix/doublespend in optimistic

### DIFF
--- a/zp-relayer/pool/RelayPool.ts
+++ b/zp-relayer/pool/RelayPool.ts
@@ -354,7 +354,7 @@ export class RelayPool extends BasePool<Network> {
   protected async localCacheObserverWorker(fromIndex: number): Promise<void> {
     // we start checking transactions slightly earlier than the current optimistic index
     // to cover the case when the indexer was already updated before onSend was called
-    const OFFSET_MARGIN = 10;
+    const OFFSET_MARGIN = 10 * OUTPLUSONE;
     fromIndex = Math.max(fromIndex - OFFSET_MARGIN, 0);
     logger.debug('Local cache observer worker was started', { fromIndex })
     const CACHE_OBSERVE_INTERVAL_MS = 1000; // waiting time between checks

--- a/zp-relayer/pool/RelayPool.ts
+++ b/zp-relayer/pool/RelayPool.ts
@@ -302,7 +302,7 @@ export class RelayPool extends BasePool<Network> {
     }
   }
 
-  protected async cacheTxLocally(commit: string, txHash: string, memo: string, index: number) {
+  protected async cacheTxLocally(commit: string, txHash: string, memo: string, timestamp: number) {
     // store or updating local tx store
     // (we should keep sent transaction until the indexer grab them)
     const prefixedMemo = buildPrefixedMemo(
@@ -310,8 +310,8 @@ export class RelayPool extends BasePool<Network> {
       txHash,
       memo
     );
-    await this.txStore.add(commit, prefixedMemo, index);
-    logger.info('Tx has been CACHED locally', { commit, index });
+    await this.txStore.add(commit, prefixedMemo, timestamp);
+    logger.info('Tx has been CACHED locally', { commit, timestamp });
   }
 
   private async getIndexerInfo() {

--- a/zp-relayer/state/TxStore.ts
+++ b/zp-relayer/state/TxStore.ts
@@ -1,37 +1,37 @@
 import { hexToNumber, numberToHexPadded } from '@/utils/helpers';
 import type { Redis } from 'ioredis'
 
-const INDEX_BYTES = 6;
+const TIMESTAMP_BYTES = 6; // enough for another ~8000 years
 
 export class TxStore {
   constructor(public name: string, private redis: Redis) {}
 
-  async add(commitment: string, memo: string, index: number) {
-    await this.redis.hset(this.name, { [commitment]: `${numberToHexPadded(index, INDEX_BYTES)}${memo}` })
+  async add(commitment: string, memo: string, timestamp: number) {
+    await this.redis.hset(this.name, { [commitment]: `${numberToHexPadded(timestamp, TIMESTAMP_BYTES)}${memo}` })
   }
 
   async remove(commitment: string) {
     await this.redis.hdel(this.name, commitment)
   }
 
-  async get(commitment: string): Promise<{memo: string, index: number} | null> {
+  async get(commitment: string): Promise<{memo: string, timestamp: number} | null> {
     const data = await this.redis.hget(this.name, commitment);
 
     return data ? { 
-      memo: data.slice(INDEX_BYTES * 2),
-      index: hexToNumber(data.slice(0, INDEX_BYTES * 2)),
+      memo: data.slice(TIMESTAMP_BYTES * 2),
+      timestamp: hexToNumber(data.slice(0, TIMESTAMP_BYTES * 2)),
     } : null;
   }
 
-  async getAll(): Promise<Record<string, {memo: string, index: number}>> {
+  async getAll(): Promise<Record<string, {memo: string, timestamp: number}>> {
     return this.redis.hgetall(this.name).then(keys => Object.fromEntries(
       Object.entries(keys)
         .map(([commit, data]) => 
           [commit,
           { 
-            memo: data.slice(INDEX_BYTES * 2),
-            index: hexToNumber(data.slice(0, INDEX_BYTES * 2)),
-          }] as [string, {memo: string, index: number}]
+            memo: data.slice(TIMESTAMP_BYTES * 2),
+            timestamp: hexToNumber(data.slice(0, TIMESTAMP_BYTES * 2)),
+          }] as [string, {memo: string, timestamp: number}]
         )
       ));
   }


### PR DESCRIPTION
This PR more or less replicates the behavior of https://github.com/zkBob/zeropool-relayer/pull/226 but replaces optimistic indexes with timestamps. 

The general idea is to maintain a cache of pending transactions. These pending transactions are merged with already indexed transactions in response to a `/transactions/v2` request. The merge process is straightforward: it removes duplicates between the indexed and pending transactions based on commitment and adds the remaining pending transactions, sorted by timestamp, up to the specified limit.

There are three events that trigger the removal of pending transactions:
* The sent transaction fails.
* The transaction is indexed by the indexer.
* The transaction has been in the cache for too long (1 day), though ideally, this situation should never occur.

One consequence of this PR is that `pendingDeltaIndex` in the `/info` response is now less accurate. However, this shouldn't be an issue, as it is only used to estimate the `limit` value for the `/transactions/v2` request.